### PR TITLE
feat: Add comprehensive server documentation

### DIFF
--- a/docs/server/01-installation.md
+++ b/docs/server/01-installation.md
@@ -1,0 +1,33 @@
+# Installation 🚀
+
+This guide will walk you through the process of installing the CandyPack server.
+
+## Quick Install ⚡
+
+This is the recommended method for most users.
+
+### Linux & macOS 🐧
+
+Run the following command in your terminal:
+
+```bash
+curl -sL https://candypack.dev/install | bash
+```
+
+### Windows 🪟
+
+Open PowerShell as an administrator and run the following command:
+
+```powershell
+iex (iwr -useb 'https://candypack.dev/install')
+```
+
+## Manual Installation (via NPM) 📦
+
+If you prefer to install manually or have issues with the quick install script, you can install CandyPack directly from NPM.
+
+1.  **Install Node.js:** Ensure you have Node.js (v18+) installed on your system. You can download it from [nodejs.org](https://nodejs.org/).
+2.  **Install CandyPack 🍭:** Use npm to install CandyPack globally:
+    ```bash
+    npm install -g candypack
+    ```

--- a/docs/server/02-get-started.md
+++ b/docs/server/02-get-started.md
@@ -1,0 +1,49 @@
+# Getting Started
+
+This guide covers the core concepts of the CandyPack server and its basic command-line interface (CLI) commands.
+
+## Core Concepts 🧠
+
+CandyPack is designed to be a powerful, developer-first toolkit that runs as a persistent background service on your server. Here’s how it works:
+
+- **Background Service:** Once started, CandyPack runs continuously in the background, managing all your configured websites and services. You don't need to manually keep it active.
+- **CLI Control:** You interact with and control the CandyPack server through the `candy` command-line tool. This tool allows you to start, stop, monitor, and manage your applications.
+- **Automation:** The primary goal of CandyPack is to automate common server management tasks, such as SSL certificate renewal, service monitoring, and application deployment, allowing you to focus on development.
+
+## Basic Commands 💻
+
+These are the most common commands for interacting with the CandyPack server.
+
+### Check Status
+To see the current status of the CandyPack server, including uptime and the number of running services, simply run the `candy` command with no arguments:
+```bash
+candy
+```
+
+### Restart the Server
+If you need to apply new configurations or restart all services, you can use the `restart` command:
+```bash
+candy restart
+```
+
+### Monitor Services
+To get a real-time, interactive view of your running websites and services, use the `monit` command:
+```bash
+candy monit
+```
+
+### View Live Logs
+For debugging purposes, you can view a live stream of all server and application logs with the `debug` command:
+```bash
+candy debug
+```
+
+### Get Help
+To see a list of all available commands, use the `help` command:
+```bash
+candy help
+```
+
+---
+
+**Next Steps:** For more advanced topics, such as managing websites, services, SSL certificates, and mail accounts, please refer to the upcoming documentation files.

--- a/docs/server/03-service.md
+++ b/docs/server/03-service.md
@@ -1,0 +1,29 @@
+# Running a Service ⚙️
+
+CandyPack allows you to run custom applications or services persistently in the background. This is useful for Node.js applications, scripts, or any other long-running processes.
+
+The `run` command is used to start a new service.
+
+## Start a New Service
+
+To start a new service, use the `run` command followed by the path to your application's entry file.
+
+### Usage
+```bash
+candy run <file>
+```
+
+### Arguments
+- `<file>`: The path to the script or application entry point you want to run. This can be an absolute path or a relative path from your current directory.
+
+### Example
+If you have a Node.js application with an `index.js` file, you can start it as a service like this:
+```bash
+candy run /path/to/your/app/index.js
+```
+or from within the app's directory:
+```bash
+candy run index.js
+```
+
+Once started, CandyPack will monitor the service and automatically restart it if it crashes. You can view its status and logs using the `monit` and `debug` commands.

--- a/docs/server/04-web.md
+++ b/docs/server/04-web.md
@@ -1,0 +1,31 @@
+# Managing Websites 🌐
+
+One of the primary functions of CandyPack is to create and manage websites. The `web` command is your entry point for all website-related operations.
+
+## Create a Website
+This command helps you set up a new website on your server. CandyPack will ask for the domain name and the path to the website's files.
+
+### Usage
+```bash
+candy web create
+```
+After running the command, you will be prompted to enter the following information:
+- **Domain Name:** The primary domain for your website (e.g., `example.com`).
+- **Path:** The absolute path to your website's root directory (e.g., `/var/www/example.com`). If you leave this blank, CandyPack will suggest a default path based on the domain name.
+
+### Example
+```bash
+$ candy web create
+> Enter the domain name: example.com
+> Enter the path to the website (/home/user/example.com/):
+```
+
+## List Websites
+To see a list of all websites currently configured on your server, use the `list` command.
+
+### Usage
+```bash
+candy web list
+```
+
+This command will output a table of your websites, showing their status and other relevant details.

--- a/docs/server/05-subdomain.md
+++ b/docs/server/05-subdomain.md
@@ -1,0 +1,35 @@
+# Managing Subdomains 🔗
+
+CandyPack makes it easy to manage subdomains for your main websites. The `subdomain` command is used for all subdomain-related tasks.
+
+## Create a Subdomain
+This command allows you to create a new subdomain. CandyPack will automatically configure it to point to a directory with the same name inside your main domain's root directory.
+
+### Usage
+```bash
+candy subdomain create
+```
+After running the command, you will be prompted to enter the new subdomain name, including the main domain (e.g., `blog.example.com`).
+
+### Example
+```bash
+$ candy subdomain create
+> Enter the subdomain name (subdomain.example.com): blog.example.com
+```
+
+## List Subdomains
+To see a list of all subdomains configured for a specific domain, use the `list` command.
+
+### Usage
+```bash
+candy subdomain list
+```
+This command will prompt you to enter the main domain name for which you want to list the subdomains.
+
+### Example
+```bash
+$ candy subdomain list
+> Enter the domain name: example.com
+```
+
+This will display a list of all subdomains associated with `example.com`.

--- a/docs/server/06-ssl.md
+++ b/docs/server/06-ssl.md
@@ -1,0 +1,22 @@
+# Managing SSL 🔒
+
+CandyPack automates the process of obtaining and renewing SSL certificates for your websites, ensuring they are always served over a secure HTTPS connection.
+
+While this process is largely automatic, you can manually trigger a renewal for a specific domain using the `ssl` command.
+
+## Renew an SSL Certificate
+This command attempts to renew the SSL certificate for a given domain. This can be useful if a certificate is close to expiring and you want to force an early renewal.
+
+### Usage
+```bash
+candy ssl renew
+```
+After running the command, you will be prompted to enter the domain name for which you want to renew the SSL certificate.
+
+### Example
+```bash
+$ candy ssl renew
+> Enter the domain name: example.com
+```
+
+CandyPack will then handle the process of validating your domain and renewing the certificate.

--- a/docs/server/07-mail.md
+++ b/docs/server/07-mail.md
@@ -1,0 +1,39 @@
+# Managing Mail ✉️
+
+CandyPack includes a mail server and provides a set of commands to manage email accounts for your domains. The `mail` command is the entry point for all mail-related operations.
+
+## Create a Mail Account
+This command allows you to create a new email account.
+
+### Usage
+```bash
+candy mail create
+```
+You will be prompted to enter the new email address and a password for the account.
+
+## Delete a Mail Account
+This command removes an existing email account.
+
+### Usage
+```bash
+candy mail delete
+```
+You will be prompted to enter the email address you wish to delete.
+
+## List Mail Accounts
+This command lists all email accounts associated with a specific domain.
+
+### Usage
+```bash
+candy mail list
+```
+You will be prompted to enter the domain name (e.g., `example.com`) to see all its email accounts.
+
+## Change Account Password
+This command allows you to change the password for an existing email account.
+
+### Usage
+```bash
+candy mail password
+```
+You will be prompted to enter the email address and the new password.


### PR DESCRIPTION
This commit adds a suite of documentation files to the `docs/server/` directory, covering installation, usage, and command modules.

The following files have been added:
- `01-installation.md`: How to install CandyPack.
- `02-get-started.md`: Core concepts and basic commands.
- `03-service.md`: How to run custom services.
- `04-web.md`: How to manage websites.
- `05-subdomain.md`: How to manage subdomains.
- `06-ssl.md`: How to manage SSL certificates.
- `07-mail.md`: How to manage mail accounts.

This completes the initial documentation for the server as requested.