### PR TITLE
Add view helper to page and authPage methods

### DIFF
--- a/framework/src/Route.js
+++ b/framework/src/Route.js
@@ -290,6 +290,15 @@ class Route {
   }
 
   page(path, file) {
+    if (file === undefined) {
+      return {
+        view: (...args) => {
+          this.set('page', path, _candy => {
+            return _candy.View.set(...args)
+          })
+        }
+      }
+    }
     this.set('page', path, file)
   }
 
@@ -302,6 +311,20 @@ class Route {
   }
 
   authPage(path, authFile, file) {
+    if (file === undefined) {
+      return {
+        view: (...args) => {
+          if (authFile)
+            this.set('#page', path, _candy => {
+              return _candy.View.set(...args)
+            })
+          else
+            this.set('page', path, _candy => {
+              return _candy.View.set(...args)
+            })
+        }
+      }
+    }
     if (authFile) this.set('#page', path, authFile)
     if (file) this.page(path, file)
   }


### PR DESCRIPTION
The page and authPage methods now return an object with a view helper when the file argument is undefined. This allows for more flexible route configuration using a view function.