### PR TITLE
fix: Add missing conventional-changelog-conventionalcommits dependenc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@semantic-release/github": "^11.0.4",
     "@semantic-release/npm": "^12.0.2",
     "@semantic-release/release-notes-generator": "^14.0.3",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",


### PR DESCRIPTION
…y (#22)

The 'semantic-release' configuration uses the 'conventionalcommits' preset, which requires the 'conventional-changelog-conventionalcommits' package. This package was missing from the devDependencies, causing a "Cannot find module" error when running release scripts.

This change adds the required package to devDependencies to resolve the error.