### PR TITLE
fix: Resolve semantic-release configuration and dependency errors

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -7,7 +7,9 @@ module.exports = {
     ["@semantic-release/release-notes-generator", {
       preset: 'conventionalcommits',
       writerOpts: {
-        transform: (commit, context) => {
+        transform: (c, context) => {
+          const commit = JSON.parse(JSON.stringify(c));
+
           const map = {
             feat: "✨ What's New",
             fix: '🛠️ Fixes & Improvements',
@@ -21,7 +23,6 @@ module.exports = {
             ci: '🤖 CI'
           };
 
-          if (!commit.type) return commit;
           commit.type = map[commit.type] || commit.type;
 
           const hide = ['🎨 Style', '🔧 Maintenance & Cleanup', '🏗️ Build', '🤖 CI'];

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@semantic-release/github": "^11.0.4",
     "@semantic-release/npm": "^12.0.2",
     "@semantic-release/release-notes-generator": "^14.0.3",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",


### PR DESCRIPTION
This commit addresses two issues preventing semantic-release from running successfully.

First, it adds the `conventional-changelog-conventionalcommits` package as a dev dependency. This package is required by the `conventionalcommits` preset used in the semantic-release configuration but was missing.

Second, it resolves a "Cannot modify immutable object" error in the release notes generator. The `commit` object passed to the transform function is now immutable. The function has been updated to create a deep copy of the commit before applying transformations, ensuring the original object is not modified.