### PR TITLE
feat: Added 'candy web delete' command.

### DIFF
--- a/cli/src/Connector.js
+++ b/cli/src/Connector.js
@@ -8,11 +8,11 @@ class Connector {
       axios
         .post('http://127.0.0.1:1453', command, {headers: {Authorization: Candy.core('Config').config.api.auth}})
         .then(response => {
-          if (response.data.message) log(response.data.message)
+          if (response.data.message) console.log(response.data.message)
           resolve(response.data)
         })
         .catch(error => {
-          log(error)
+          console.error(error)
           reject(error)
         })
     })

--- a/core/Commands.js
+++ b/core/Commands.js
@@ -122,6 +122,16 @@ module.exports = {
           })
         }
       },
+      delete: {
+        description: 'Delete a website',
+        action: async () => {
+          let domain = await Candy.cli('Cli').question('Enter the domain name: ')
+          await Candy.cli('Connector').call({
+            action: 'web.delete',
+            data: [domain]
+          })
+        }
+      },
       list: {
         description: 'List all websites',
         action: async () => await Candy.cli('Connector').call({action: 'web.list'})

--- a/server/src/Api.js
+++ b/server/src/Api.js
@@ -14,6 +14,7 @@ class Api {
     'subdomain.create': (...args) => Candy.server('Subdomain').create(...args),
     'subdomain.list': (...args) => Candy.server('Subdomain').list(...args),
     'web.create': (...args) => Candy.server('Web').create(...args),
+    'web.delete': (...args) => Candy.server('Web').delete(...args),
     'web.list': (...args) => Candy.server('Web').list(...args)
   }
 


### PR DESCRIPTION
* feat: Add 'candy web delete' command

This commit introduces the `candy web delete` command, allowing users to remove existing websites.

The implementation includes:
- A new `delete` method in `server/src/Web.js` to handle the deletion logic, including process termination, file removal, and DNS record cleanup.
- An update to `server/src/Api.js` to expose the `web.delete` action.
- The addition of the `delete` subcommand to `core/Commands.js` for the CLI.

* refactor: Modify 'web delete' to only remove config

Based on user feedback, this commit alters the `candy web delete` command to only remove the website's configuration and stop its running process.

The command no longer deletes the website's files from the filesystem or its associated DNS records.

* fix: CLI log problem fixed

Swapped out the custom 'log' function for standard console.log and console.error in the Connector class to improve clarity and consistency in logging.

* Fix crash if website config is missing on child exit

Added a check to ensure the website config exists before accessing its properties in the child process 'exit' handler. This prevents potential runtime errors if the config was removed before the handler executes.

* Refactor Web.js for cleaner logic and null checks

Simplified the delete method by condensing for-loop and moving process stop logic after deletion. Added checks to ensure website config exists before updating status in log and error handlers to prevent possible runtime errors.

---------