### PR TITLE
test: Added Unit Tests for Log Module

### DIFF
--- a/server/src/Log.js
+++ b/server/src/Log.js
@@ -13,12 +13,13 @@ class Log {
 
   log(...arg) {
     if (!arg.length) return this
-    if (arg[0].includes('%s')) {
-      let split = arg[0].split('%s')
-      for (let i = 0; i < split.length - 1; i++) {
-        split[i] += arg[1] || ''
-        arg.splice(1, 1)
+    if (typeof arg[0] === 'string' && arg[0].includes('%s')) {
+      let message = arg.shift()
+      while (message.includes('%s') && arg.length > 0) {
+        message = message.replace('%s', arg.shift())
       }
+      message = message.replace(/%s/g, '')
+      arg.unshift(message)
     }
     console.log(this.module, ...arg)
   }

--- a/test/Log.test.js
+++ b/test/Log.test.js
@@ -1,0 +1,73 @@
+const Log = require('../server/src/Log');
+
+describe('Log', () => {
+  let consoleLogSpy;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should initialize with a module prefix', () => {
+    const log = new Log();
+    const logger = log.init('TestModule');
+    logger.log('test message');
+    expect(consoleLogSpy).toHaveBeenCalledWith('[TestModule] ', 'test message');
+  });
+
+  it('should handle multiple module prefixes', () => {
+    const log = new Log();
+    const logger = log.init('Module1', 'Module2');
+    logger.log('test message');
+    expect(consoleLogSpy).toHaveBeenCalledWith('[Module1][Module2] ', 'test message');
+  });
+
+  it('should log messages correctly', () => {
+    const log = new Log();
+    const logger = log.init('Test');
+    logger.log('message1', 'message2');
+    expect(consoleLogSpy).toHaveBeenCalledWith('[Test] ', 'message1', 'message2');
+  });
+
+  it('should log error messages correctly', () => {
+    const log = new Log();
+    const logger = log.init('Test');
+    logger.error('error message');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[Test] ', 'error message');
+  });
+
+  it('should handle %s format specifiers', () => {
+    const log = new Log();
+    const logger = log.init('FormatTest');
+    logger.log('Hello, %s!', 'World');
+    expect(consoleLogSpy).toHaveBeenCalledWith('[FormatTest] ', 'Hello, World!');
+  });
+
+  it('should handle multiple %s format specifiers', () => {
+    const log = new Log();
+    const logger = log.init('FormatTest');
+    logger.log('Hello, %s! Welcome, %s.', 'John', 'Jane');
+    expect(consoleLogSpy).toHaveBeenCalledWith('[FormatTest] ', 'Hello, John! Welcome, Jane.');
+  });
+
+  it('should handle missing arguments for %s', () => {
+    const log = new Log();
+    const logger = log.init('FormatTest');
+    logger.log('Hello, %s!');
+    expect(consoleLogSpy).toHaveBeenCalledWith('[FormatTest] ', 'Hello, !');
+  });
+
+  it('should not log anything if no arguments are provided to log()', () => {
+    const log = new Log();
+    const logger = log.init('Test');
+    const result = logger.log();
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(result).toBeInstanceOf(Log);
+  });
+});


### PR DESCRIPTION
Adds a comprehensive test suite for the Log module using Jest.

The new tests cover:
- Module initialization with single and multiple prefixes.
- Standard and error message logging.
- String formatting with `%s` specifiers, including multiple and missing arguments.

Also fixes a bug in the `log` method's string formatting logic to correctly handle multiple `%s` replacements.