### PR TITLE
fix: Fix module instantiation and nullish services handling

### DIFF
--- a/core/Candy.js
+++ b/core/Candy.js
@@ -27,9 +27,10 @@ class CandyPack {
     const key = `core:${name}`
     if (!this._registry.has(key)) {
       const modPath = `../core/${name}`
-      const Mod = require(modPath)
-      if (Mod.init) Mod.init()
-      this.#register(key, Mod, singleton)
+      let Mod = require(modPath)
+      const classInstance = typeof Mod === 'function' ? new Mod() : Mod
+      if (classInstance.init) classInstance.init()
+      this.#register(key, classInstance, singleton)
     }
     return this.#resolve(key, singleton)
   }

--- a/watchdog/src/Watchdog.js
+++ b/watchdog/src/Watchdog.js
@@ -69,7 +69,7 @@ class Watchdog {
         if (Candy.core('Config').config.websites[domain].pid)
           await Candy.core('Process').stop(Candy.core('Config').config.websites[domain].pid)
 
-      for (const service of Candy.core('Config').config.services) if (service.pid) await Candy.core('Process').stop(service.pid)
+      for (const service of Candy.core('Config').config.services ?? []) if (service.pid) await Candy.core('Process').stop(service.pid)
 
       // Update config with current watchdog's info
       Candy.core('Config').config.server.watchdog = process.pid


### PR DESCRIPTION
Candy.js now instantiates modules if they are classes before initialization, ensuring correct usage of class-based modules. Watchdog.js now safely iterates over services using nullish coalescing to prevent errors when services is undefined.