### PR TITLE
Sync `dev` to `main`

### DIFF
--- a/server/src/App.js
+++ b/server/src/App.js
@@ -196,7 +196,7 @@ class App {
       // Legacy fix: If no port in config, assume 3000 and SAVE IT
       // so Proxy service can see it immediately
       log('Legacy App Fix: Assigning default port 3000 to app %s', app.name)
-      app.ports = [{container: 3000}]
+      app.ports = [{host: Odac.server('Ports').PROXY, container: 3000}]
       this.#saveApps()
     }
 
@@ -272,6 +272,23 @@ class App {
         // It might be an ephemeral/debug port (like 45769) while the main port (3000) is starting.
         // We give it 5 seconds (attempts < 5) to see if the expected port appears.
         if (attempts >= 5) {
+          const ports = Odac.server('Ports')
+          const primary = app.ports?.[0]
+
+          // A published host binding is a contract the caller declared and Docker
+          // already applied at container create time. Rewriting the container port
+          // here would orphan that binding, so leave the config alone.
+          if (ports.isPublished(primary)) {
+            log(
+              'Auto-Discovery: App %s listens on %s but publishes %s:%d. Keeping the declared binding.',
+              app.name,
+              listeningPorts.join(','),
+              primary.host,
+              primary.container
+            )
+            return
+          }
+
           let preferred = null
 
           // HTTP Probe: When multiple ports are open, identify the actual HTTP port
@@ -290,7 +307,10 @@ class App {
           }
 
           log('Auto-Discovery: App %s is listening on port %d (expected %d). Updating config...', app.name, preferred, expectedPort)
-          app.ports = [{container: preferred}]
+
+          // Correct only the primary entry; secondary mappings are untouched.
+          const rest = app.ports?.slice(1) || []
+          app.ports = [{host: ports.PROXY, container: preferred}, ...rest]
 
           // Cache container IP for zero-downtime Proxy routing
           if (containerIP) app.ip = containerIP
@@ -1027,8 +1047,9 @@ class App {
 
   /**
    * Replaces the port mappings for an app with a new set.
-   * Validates each entry for correct structure and port range (1-65535).
-   * Auto-assigns host ports when 'auto' is specified.
+   * Validates each entry for correct structure and port range (1-65535),
+   * rejects mappings that would silently collide, and auto-assigns host ports
+   * when 'auto' is specified.
    * @param {string|number} id - App id, name, or file
    * @param {Array<{host: number|string, container: number}>} ports - New port mappings
    * @returns {object} Api.result
@@ -1043,25 +1064,34 @@ class App {
       return Odac.server('Api').result(false, __('Invalid ports payload. Expected an array.'))
     }
 
-    // Validate each port mapping
+    // Validate each port mapping. Both sides are mandatory: an entry with no host
+    // is ambiguous now that proxy ownership has an explicit spelling.
+    const {PROXY} = Odac.server('Ports')
     for (const entry of ports) {
       if (!entry || typeof entry !== 'object') {
         return Odac.server('Api').result(false, __('Invalid port entry. Expected {host, container}.'))
       }
-      if (entry.container === undefined || entry.container === null) {
+      if (entry.container === undefined || entry.container === null || entry.container === '') {
         return Odac.server('Api').result(false, __('Each port entry must have a container port.'))
       }
       const containerPort = Number(entry.container)
       if (!Number.isInteger(containerPort) || containerPort < 1 || containerPort > 65535) {
         return Odac.server('Api').result(false, __('Invalid container port: %s. Must be 1-65535.', entry.container))
       }
-      if (entry.host !== undefined && entry.host !== 'auto') {
+      if (entry.host === undefined || entry.host === null || entry.host === '') {
+        return Odac.server('Api').result(false, __('Each port entry must have a host port, "auto", or "%s".', PROXY))
+      }
+      if (entry.host !== 'auto' && entry.host !== PROXY) {
         const hostPort = Number(entry.host)
         if (!Number.isInteger(hostPort) || hostPort < 1 || hostPort > 65535) {
-          return Odac.server('Api').result(false, __('Invalid host port: %s. Must be 1-65535 or "auto".', entry.host))
+          return Odac.server('Api').result(false, __('Invalid host port: %s. Must be 1-65535, "auto", or "%s".', entry.host, PROXY))
         }
       }
     }
+
+    // Reject sets that would collide instead of silently dropping an entry.
+    const collision = this.#findPortCollision(ports)
+    if (collision) return Odac.server('Api').result(false, collision)
 
     // Resolve 'auto' host ports
     const resolved = await this.#preparePorts(ports)
@@ -1318,7 +1348,14 @@ class App {
   // Private: App Data Management
   #loadAppsFromConfig() {
     const apps = Odac.core('Config').config.apps
-    return Array.isArray(apps) ? apps : []
+    if (!Array.isArray(apps)) return []
+
+    // Migrate pre-sentinel entries ({container} with no host) in place, so the
+    // dashboard sees who owns each port. Persisted on the next #saveApps().
+    const ports = Odac.server('Ports')
+    for (const app of apps) ports.normalize(app.ports)
+
+    return apps
   }
 
   #get(id) {
@@ -1558,9 +1595,9 @@ class App {
 
     const runOptions = {
       image: app.image,
-      // Only pass ports with host binding to Docker. Internal-only ports (container-only)
-      // are metadata for Proxy routing and must NOT be sent as Docker PortBindings.
-      ports: (app.ports || []).filter(p => p.host),
+      // Only pass published ports to Docker. Proxy-routed ports (host: 'proxy')
+      // are routing metadata and must NOT be sent as Docker PortBindings.
+      ports: (app.ports || []).filter(p => Odac.server('Ports').isPublished(p)),
       volumes,
       devices: app.devices || [],
       env
@@ -1661,7 +1698,7 @@ class App {
         if (exposed && exposed.length > 0) {
           const detected = exposed[0]
           log('Port Auto-Detect: Discovered port %d from image EXPOSE for app %s', detected, app.name)
-          app.ports = [{container: detected}]
+          app.ports = [{host: Odac.server('Ports').PROXY, container: detected}]
           this.#saveApps()
           return detected
         }
@@ -1672,7 +1709,7 @@ class App {
 
     // Priority 3: Fallback to default
     log('Port Auto-Detect: No port info available for app %s. Assigning default 3000.', app.name)
-    app.ports = [{container: 3000}]
+    app.ports = [{host: Odac.server('Ports').PROXY, container: 3000}]
     this.#saveApps()
     return 3000
   }
@@ -1899,22 +1936,84 @@ class App {
     })
   }
 
+  /**
+   * Finds a mapping set that Docker or the Proxy would resolve ambiguously.
+   * Each of these would otherwise be swallowed silently rather than surfaced:
+   *  - two proxy entries: only ports[0] is routed, the other is dead metadata.
+   *  - duplicate container ports: PortBindings is keyed by container port, so
+   *    the later entry overwrites the earlier one.
+   *  - duplicate host ports: Docker refuses the bind at container create time.
+   *
+   * @param {Array<{host: number|string, container: number|string}>} ports - Validated entries
+   * @returns {string|false} Localized error message, or false when the set is sound
+   */
+  #findPortCollision(ports) {
+    const {PROXY} = Odac.server('Ports')
+    const seenContainer = new Set()
+    const seenHost = new Set()
+    let proxyCount = 0
+
+    for (const entry of ports) {
+      const containerPort = Number(entry.container)
+      if (seenContainer.has(containerPort)) {
+        return __('Duplicate container port: %s. Each container port may be mapped once.', entry.container)
+      }
+      seenContainer.add(containerPort)
+
+      if (entry.host === PROXY) {
+        if (++proxyCount > 1) {
+          return __('Only one port may be routed by the proxy. Publish the others on a host port.')
+        }
+        continue
+      }
+
+      // 'auto' resolves to a distinct free port per entry, so it cannot collide here.
+      if (entry.host === 'auto') continue
+
+      const hostPort = Number(entry.host)
+      if (seenHost.has(hostPort)) {
+        return __('Duplicate host port: %s. Each host port may be bound once.', entry.host)
+      }
+      seenHost.add(hostPort)
+    }
+
+    return false
+  }
+
+  /**
+   * Canonicalizes port entries before they are persisted: resolves 'auto' host
+   * ports, defaults an omitted host to the proxy sentinel (recipes and legacy
+   * callers may still omit it), and coerces ports to numbers so downstream
+   * readiness checks (`listeningPorts.includes(port)`) compare like with like.
+   *
+   * @param {Array<{host?: number|string, container: number|string}>} recipePorts - Raw entries
+   * @returns {Promise<Array<{host: number|string, container: number}>>} Canonical entries
+   */
   async #preparePorts(recipePorts) {
     if (!recipePorts) return []
 
+    const {PROXY} = Odac.server('Ports')
+    // Auto-assigned ports are not bound yet, so #isPortInUse cannot see them.
+    // Track them here or two 'auto' entries would resolve to the same port.
+    const assigned = new Set()
     const ports = []
+
     for (const port of recipePorts) {
-      const hostPort = port.host === 'auto' ? await this.#findAvailablePort(30000) : port.host
-      ports.push({host: hostPort, container: port.container})
+      let host = port.host ?? PROXY
+      if (host === 'auto') host = await this.#findAvailablePort(30000, assigned)
+      else if (host !== PROXY) host = Number(host)
+
+      if (host !== PROXY) assigned.add(host)
+      ports.push({host, container: Number(port.container)})
     }
 
     return ports
   }
 
   // Private: Port Management
-  async #findAvailablePort(start) {
+  async #findAvailablePort(start, assigned = new Set()) {
     let port = start
-    while (await this.#isPortInUse(port)) port++
+    while (assigned.has(port) || (await this.#isPortInUse(port))) port++
     return port
   }
 

--- a/server/src/App.js
+++ b/server/src/App.js
@@ -260,58 +260,80 @@ class App {
 
     try {
       const container = Odac.server('Container')
+      const ports = Odac.server('Ports')
+      const primary = ports.primary(app.ports)
       const listeningPorts = await container.getListeningPorts(app.name)
 
       if (listeningPorts.length > 0) {
         // App has started listening!
 
-        // If expected port is found, we are matched and good to go.
-        if (listeningPorts.includes(expectedPort)) return
+        // The mapping already points at a port the app binds: nothing to discover.
+        if (primary && listeningPorts.includes(primary.container)) return
 
-        // If expected port is NOT found (but some other port is),
+        // If the mapped port is NOT found (but some other port is),
         // we should not immediately jump to config update.
         // It might be an ephemeral/debug port (like 45769) while the main port (3000) is starting.
         // We give it 5 seconds (attempts < 5) to see if the expected port appears.
         if (attempts >= 5) {
-          const ports = Odac.server('Ports')
-          const primary = ports.primary(app.ports)
-
-          // Auto-discovery exists to correct a port ODAC guessed, never one that
-          // was declared. A published binding is already applied on the host, and
-          // a proxy entry the user or a recipe wrote is a setting they chose:
+          // Auto-discovery exists to correct a port ODAC guessed, or to write the
+          // first one when the app has no mapping at all — never to touch one that
+          // was declared. A published binding is already applied on the host, and a
+          // proxy entry the user or a recipe wrote is a setting they chose:
           // rewriting either would silently undo it on the next restart.
-          if (!ports.isAuto(primary)) {
+          if (primary && !ports.isAuto(primary)) {
             log(
               'Auto-Discovery: App %s listens on %s but its config declares %s. Keeping the declared port.',
               app.name,
               listeningPorts.join(','),
-              primary ? primary.container : 'nothing'
+              primary.container
             )
             return
           }
 
           let preferred = null
 
-          // HTTP Probe: When multiple ports are open, identify the actual HTTP port
-          // by sending a HEAD request. DB/Redis/WS-only ports won't respond to HTTP.
+          // HTTP Probe: a proxy mapping claims the ODAC proxy routes to that port, so
+          // only a port that answers HTTP is worth writing. Probing every open port —
+          // including a lone one — is what keeps a database app from being handed a
+          // `proxy: 3306` mapping the proxy could never route.
           const containerIP = await container.getIP(app.name)
-          if (containerIP && listeningPorts.length > 1) {
+          if (containerIP) {
             preferred = await this.#detectHttpPort(containerIP, listeningPorts)
-            if (preferred) {
-              log('Auto-Discovery: HTTP probe identified port %d for app %s', preferred, app.name)
-            }
-          }
 
-          // Fallback: well-known HTTP ports, then first available
-          if (!preferred) {
+            if (!preferred) {
+              // Nothing speaks HTTP yet. It may still come up — a slow app binds its
+              // socket before it serves — so keep polling on the remaining budget and
+              // leave the config untouched rather than claiming a non-HTTP port.
+              if (attempts === 5) {
+                log(
+                  'Auto-Discovery: App %s listens on %s but none of them answer HTTP. Leaving its ports alone.',
+                  app.name,
+                  listeningPorts.join(',')
+                )
+              }
+
+              setTimeout(() => this.#pollForPort(app, expectedPort, attempts + 1), 1000)
+              return
+            }
+
+            log('Auto-Discovery: HTTP probe identified port %d for app %s', preferred, app.name)
+          } else {
+            // No container IP means the probe cannot run at all. Guess as before:
+            // well-known HTTP ports, then the first one open.
             preferred = listeningPorts.find(p => [80, 8080, 3000, 5000].includes(p)) || listeningPorts[0]
           }
 
-          log('Auto-Discovery: App %s is listening on port %d (expected %d). Updating config...', app.name, preferred, expectedPort)
+          log('Auto-Discovery: App %s serves HTTP on port %d (expected %d). Updating config...', app.name, preferred, expectedPort)
 
-          // Correct the guessed entry in place; it stays a guess, and every other
-          // mapping keeps both its position and its contents.
-          primary.container = preferred
+          if (primary) {
+            // Correct the guessed entry in place; it stays a guess, and every other
+            // mapping keeps both its position and its contents.
+            primary.container = preferred
+          } else {
+            // The app had no mapping at all. Now that a port is known to serve HTTP,
+            // the proxy entry can be written on evidence rather than on a guess.
+            app.ports = [ports.discovered(preferred)]
+          }
 
           // Cache container IP for zero-downtime Proxy routing
           if (containerIP) app.ip = containerIP
@@ -334,7 +356,7 @@ class App {
   }
 
   /**
-   * Probes multiple container ports to detect which one speaks HTTP.
+   * Probes container ports to detect which one speaks HTTP.
    * Sends a minimal HEAD request to each port in parallel with a short timeout.
    * Non-HTTP services (databases, message queues, raw TCP) will not respond with valid HTTP.
    *
@@ -1690,18 +1712,22 @@ class App {
   }
 
   /**
-   * Resolves the internal port for a container app.
+   * The port a container app is told to listen on, via the PORT env.
    * Priority: existing config > image EXPOSE metadata > default (3000).
-   * Persists the result so Proxy can route immediately.
+   *
+   * Nothing is persisted. A proxy mapping asserts that the ODAC proxy routes to
+   * that port, and neither EXPOSE nor the 3000 default is evidence of anything
+   * serving HTTP there — a database image EXPOSEs 3306 and speaks its own wire
+   * protocol on it. Writing the assertion up front is what gave every database
+   * app a `proxy` mapping it could never honour. #pollForPort writes the mapping
+   * once its probe has found a port that actually answers HTTP.
    *
    * @param {object} app - App record
-   * @returns {Promise<number>} Resolved container port
+   * @returns {Promise<number>} Container port for PORT
    */
   async #resolveContainerPort(app) {
-    const ports = Odac.server('Ports')
-
     // Priority 1: Already configured
-    const primary = ports.primary(app.ports)
+    const primary = Odac.server('Ports').primary(app.ports)
     if (primary?.container) {
       return primary.container
     }
@@ -1711,11 +1737,8 @@ class App {
       try {
         const exposed = await Odac.server('Container').getImageExposedPorts(app.image)
         if (exposed && exposed.length > 0) {
-          const detected = exposed[0]
-          log('Port Auto-Detect: Discovered port %d from image EXPOSE for app %s', detected, app.name)
-          app.ports = [ports.discovered(detected)]
-          this.#saveApps()
-          return detected
+          log('Port Auto-Detect: Image EXPOSE suggests port %d for app %s', exposed[0], app.name)
+          return exposed[0]
         }
       } catch (e) {
         error('Port Auto-Detect: Failed to inspect image for app %s: %s', app.name, e.message)
@@ -1723,9 +1746,7 @@ class App {
     }
 
     // Priority 3: Fallback to default
-    log('Port Auto-Detect: No port info available for app %s. Assigning default 3000.', app.name)
-    app.ports = [ports.discovered(3000)]
-    this.#saveApps()
+    log('Port Auto-Detect: No port info available for app %s. Defaulting PORT to 3000.', app.name)
     return 3000
   }
 

--- a/server/src/App.js
+++ b/server/src/App.js
@@ -190,13 +190,14 @@ class App {
 
     // Safety check for legacy apps without ports config
     let port = 3000
-    if (app.ports && app.ports.length > 0 && app.ports[0].container) {
-      port = app.ports[0].container
+    const primary = Odac.server('Ports').primary(app.ports)
+    if (primary?.container) {
+      port = primary.container
     } else {
       // Legacy fix: If no port in config, assume 3000 and SAVE IT
       // so Proxy service can see it immediately
       log('Legacy App Fix: Assigning default port 3000 to app %s', app.name)
-      app.ports = [{host: Odac.server('Ports').PROXY, container: 3000}]
+      app.ports = [Odac.server('Ports').discovered(3000)]
       this.#saveApps()
     }
 
@@ -273,18 +274,18 @@ class App {
         // We give it 5 seconds (attempts < 5) to see if the expected port appears.
         if (attempts >= 5) {
           const ports = Odac.server('Ports')
-          const primary = app.ports?.[0]
+          const primary = ports.primary(app.ports)
 
-          // A published host binding is a contract the caller declared and Docker
-          // already applied at container create time. Rewriting the container port
-          // here would orphan that binding, so leave the config alone.
-          if (ports.isPublished(primary)) {
+          // Auto-discovery exists to correct a port ODAC guessed, never one that
+          // was declared. A published binding is already applied on the host, and
+          // a proxy entry the user or a recipe wrote is a setting they chose:
+          // rewriting either would silently undo it on the next restart.
+          if (!ports.isAuto(primary)) {
             log(
-              'Auto-Discovery: App %s listens on %s but publishes %s:%d. Keeping the declared binding.',
+              'Auto-Discovery: App %s listens on %s but its config declares %s. Keeping the declared port.',
               app.name,
               listeningPorts.join(','),
-              primary.host,
-              primary.container
+              primary ? primary.container : 'nothing'
             )
             return
           }
@@ -308,9 +309,9 @@ class App {
 
           log('Auto-Discovery: App %s is listening on port %d (expected %d). Updating config...', app.name, preferred, expectedPort)
 
-          // Correct only the primary entry; secondary mappings are untouched.
-          const rest = app.ports?.slice(1) || []
-          app.ports = [{host: ports.PROXY, container: preferred}, ...rest]
+          // Correct the guessed entry in place; it stays a guess, and every other
+          // mapping keeps both its position and its contents.
+          primary.container = preferred
 
           // Cache container IP for zero-downtime Proxy routing
           if (containerIP) app.ip = containerIP
@@ -1051,7 +1052,7 @@ class App {
    * rejects mappings that would silently collide, and auto-assigns host ports
    * when 'auto' is specified.
    * @param {string|number} id - App id, name, or file
-   * @param {Array<{host: number|string, container: number}>} ports - New port mappings
+   * @param {Array<{host: number|string, container: number, public?: boolean}>} ports - New port mappings
    * @returns {object} Api.result
    */
   async setPorts(id, ports) {
@@ -1066,7 +1067,8 @@ class App {
 
     // Validate each port mapping. Both sides are mandatory: an entry with no host
     // is ambiguous now that proxy ownership has an explicit spelling.
-    const {PROXY} = Odac.server('Ports')
+    const portsApi = Odac.server('Ports')
+    const {PROXY} = portsApi
     for (const entry of ports) {
       if (!entry || typeof entry !== 'object') {
         return Odac.server('Api').result(false, __('Invalid port entry. Expected {host, container}.'))
@@ -1086,6 +1088,16 @@ class App {
         if (!Number.isInteger(hostPort) || hostPort < 1 || hostPort > 65535) {
           return Odac.server('Api').result(false, __('Invalid host port: %s. Must be 1-65535, "auto", or "%s".', entry.host, PROXY))
         }
+      }
+
+      // A public entry reaches the internet, so an unparseable flag must fail
+      // loudly rather than fall back to either interpretation.
+      const isPublic = portsApi.parsePublic(entry.public)
+      if (isPublic === null) {
+        return Odac.server('Api').result(false, __('Invalid public flag: %s. Must be true or false.', entry.public))
+      }
+      if (isPublic && entry.host === PROXY) {
+        return Odac.server('Api').result(false, __('A "%s" port cannot be public. Give it a host port to publish it.', PROXY))
       }
     }
 
@@ -1686,9 +1698,12 @@ class App {
    * @returns {Promise<number>} Resolved container port
    */
   async #resolveContainerPort(app) {
+    const ports = Odac.server('Ports')
+
     // Priority 1: Already configured
-    if (app.ports && app.ports.length > 0 && app.ports[0].container) {
-      return app.ports[0].container
+    const primary = ports.primary(app.ports)
+    if (primary?.container) {
+      return primary.container
     }
 
     // Priority 2: Auto-detect from Docker image EXPOSE
@@ -1698,7 +1713,7 @@ class App {
         if (exposed && exposed.length > 0) {
           const detected = exposed[0]
           log('Port Auto-Detect: Discovered port %d from image EXPOSE for app %s', detected, app.name)
-          app.ports = [{host: Odac.server('Ports').PROXY, container: detected}]
+          app.ports = [ports.discovered(detected)]
           this.#saveApps()
           return detected
         }
@@ -1709,7 +1724,7 @@ class App {
 
     // Priority 3: Fallback to default
     log('Port Auto-Detect: No port info available for app %s. Assigning default 3000.', app.name)
-    app.ports = [{host: Odac.server('Ports').PROXY, container: 3000}]
+    app.ports = [ports.discovered(3000)]
     this.#saveApps()
     return 3000
   }
@@ -1939,27 +1954,22 @@ class App {
   /**
    * Finds a mapping set that Docker or the Proxy would resolve ambiguously.
    * Each of these would otherwise be swallowed silently rather than surfaced:
-   *  - two proxy entries: only ports[0] is routed, the other is dead metadata.
-   *  - duplicate container ports: PortBindings is keyed by container port, so
-   *    the later entry overwrites the earlier one.
+   *  - two proxy entries: only one can be routed, the other is dead metadata.
    *  - duplicate host ports: Docker refuses the bind at container create time.
+   *
+   * A container port may legitimately repeat: the proxy reaches it over the
+   * container network while Docker publishes it on the host, and Docker accepts
+   * several host bindings for one container port.
    *
    * @param {Array<{host: number|string, container: number|string}>} ports - Validated entries
    * @returns {string|false} Localized error message, or false when the set is sound
    */
   #findPortCollision(ports) {
     const {PROXY} = Odac.server('Ports')
-    const seenContainer = new Set()
     const seenHost = new Set()
     let proxyCount = 0
 
     for (const entry of ports) {
-      const containerPort = Number(entry.container)
-      if (seenContainer.has(containerPort)) {
-        return __('Duplicate container port: %s. Each container port may be mapped once.', entry.container)
-      }
-      seenContainer.add(containerPort)
-
       if (entry.host === PROXY) {
         if (++proxyCount > 1) {
           return __('Only one port may be routed by the proxy. Publish the others on a host port.')
@@ -1986,17 +1996,18 @@ class App {
    * callers may still omit it), and coerces ports to numbers so downstream
    * readiness checks (`listeningPorts.includes(port)`) compare like with like.
    *
-   * @param {Array<{host?: number|string, container: number|string}>} recipePorts - Raw entries
-   * @returns {Promise<Array<{host: number|string, container: number}>>} Canonical entries
+   * @param {Array<{host?: number|string, container: number|string, public?: boolean}>} recipePorts - Raw entries
+   * @returns {Promise<Array<{host: number|string, container: number, public?: boolean}>>} Canonical entries
    */
   async #preparePorts(recipePorts) {
     if (!recipePorts) return []
 
-    const {PROXY} = Odac.server('Ports')
+    const ports = Odac.server('Ports')
+    const {PROXY} = ports
     // Auto-assigned ports are not bound yet, so #isPortInUse cannot see them.
     // Track them here or two 'auto' entries would resolve to the same port.
     const assigned = new Set()
-    const ports = []
+    const prepared = []
 
     for (const port of recipePorts) {
       let host = port.host ?? PROXY
@@ -2004,10 +2015,16 @@ class App {
       else if (host !== PROXY) host = Number(host)
 
       if (host !== PROXY) assigned.add(host)
-      ports.push({host, container: Number(port.container)})
+
+      const entry = {host, container: Number(port.container)}
+      // Only stamp the flag when it is on: an absent `public` already means
+      // loopback, so writing `false` everywhere would churn every stored config.
+      if (host !== PROXY && ports.parsePublic(port.public) === true) entry.public = true
+
+      prepared.push(entry)
     }
 
-    return ports
+    return prepared
   }
 
   // Private: Port Management

--- a/server/src/App.js
+++ b/server/src/App.js
@@ -18,7 +18,7 @@ const SCRIPT_RUNNERS = {
   '.rb': {image: 'ruby:alpine', cmd: 'ruby', local: 'ruby'},
   '.sh': {image: 'alpine:latest', cmd: 'sh', local: 'sh'}
 }
-const SENSITIVE_KEY_PATTERN = /cert|key|pass|salt|secret|token/i
+const SENSITIVE_KEY_PATTERN = /cert|key|salt|secret|token/i
 
 class App {
   #apps = []
@@ -867,7 +867,7 @@ class App {
   /**
    * Returns the environment variables for a specific app in structured format.
    * Manual envs and linked app envs are returned separately for frontend display.
-   * Sensitive values (pass, key, secret, token, cert, salt) are masked.
+   * Sensitive values (key, secret, token, cert, salt) are masked.
    * @param {string|number} id - App id, name, or file
    * @returns {object} Api.result with { manual: {}, linked: [{app, env}] }
    */

--- a/server/src/App/Create.js
+++ b/server/src/App/Create.js
@@ -453,7 +453,7 @@ class Create {
             manual: env.manual || Array.isArray(env.linked) ? env.manual || {} : env,
             linked: env.manual || Array.isArray(env.linked) ? env.linked || [] : linked || []
           },
-          ports: [{container: parseInt(detectedPort)}],
+          ports: [{host: Odac.server('Ports').PROXY, container: parseInt(detectedPort)}],
           dev,
           active: true,
           created: Date.now(),

--- a/server/src/App/Deploy.js
+++ b/server/src/App/Deploy.js
@@ -26,7 +26,7 @@ class Deploy {
 
     if (!app.ports || app.ports.length === 0 || !app.ports[0].container) {
       log('Legacy App Fix: Assigning default port 3000 to app %s during %s', app.name, operation.toLowerCase())
-      app.ports = [{container: 3000}]
+      app.ports = [{host: Odac.server('Ports').PROXY, container: 3000}]
       api.saveApps()
     }
 

--- a/server/src/App/Deploy.js
+++ b/server/src/App/Deploy.js
@@ -24,9 +24,10 @@ class Deploy {
       throw new Error('Blue-Green deploy requires a runGreenContainer function.')
     }
 
-    if (!app.ports || app.ports.length === 0 || !app.ports[0].container) {
+    const ports = Odac.server('Ports')
+    if (!ports.primary(app.ports)?.container) {
       log('Legacy App Fix: Assigning default port 3000 to app %s during %s', app.name, operation.toLowerCase())
-      app.ports = [{host: Odac.server('Ports').PROXY, container: 3000}]
+      app.ports = [ports.discovered(3000)]
       api.saveApps()
     }
 
@@ -41,8 +42,9 @@ class Deploy {
     api.set(app.id, {status: 'switching'})
 
     let expectedPort = 3000
-    if (app.ports && app.ports.length > 0 && app.ports[0].container) {
-      expectedPort = app.ports[0].container
+    const primary = ports.primary(app.ports)
+    if (primary?.container) {
+      expectedPort = primary.container
     }
 
     let isReady = false

--- a/server/src/Container.js
+++ b/server/src/Container.js
@@ -6,6 +6,7 @@ const NODE_IMAGE = 'node:lts-alpine'
 
 const Builder = require('./Container/Builder')
 const Logger = require('./Container/Logger')
+const Terminal = require('./Container/Terminal')
 
 class Container {
   #docker
@@ -428,6 +429,59 @@ class Container {
     } catch (err) {
       throw new Error(`Failed to exec command in ${name}: ${err.message}`)
     }
+  }
+
+  /**
+   * Opens an interactive shell inside a managed app's container.
+   *
+   * Takes an APP name, never a raw container name or id: the caller is ultimately the Hub,
+   * and resolving through the app list is what keeps a spoofed command from opening a shell
+   * in a container odac does not manage — including odac's own, which mounts the Docker
+   * socket and would hand over the host.
+   *
+   * @param {string} appName
+   * @param {Object} [options] - Passed through to Terminal (onData, onExit, cols, rows, …)
+   * @param {boolean} [options.allowPrivileged] - Permit a shell in a --privileged container
+   * @returns {Promise<Terminal>} An opened session
+   */
+  async createTerminalSession(appName, options = {}) {
+    if (!this.available) throw new Error('Docker is not available')
+
+    const res = await Odac.server('App').list()
+    const apps = res?.result ? res.data : []
+
+    if (!Array.isArray(apps) || !apps.some(app => app.name === appName)) {
+      throw new Error(`Unknown app: ${appName}`)
+    }
+
+    // One inspect answers all three gates below: running, privileged, and which user the app
+    // itself runs as.
+    let info
+    try {
+      info = await this.#docker.getContainer(appName).inspect()
+    } catch (e) {
+      if (e.statusCode === 404) throw new Error(`Container ${appName} is not running`)
+      throw e
+    }
+
+    if (!info.State?.Running) {
+      throw new Error(`Container ${appName} is not running`)
+    }
+
+    // A shell in a --privileged container has the host's devices and kernel capabilities: it is
+    // a host shell in container clothing. Refuse unless the operator has explicitly opted in.
+    if (info.HostConfig?.Privileged && !options.allowPrivileged) {
+      throw new Error(`Refusing a terminal in privileged container ${appName}`)
+    }
+
+    // Run as the app's own user rather than root. An image that declares USER gets that user;
+    // one that runs as root still can, but only because the image chose to — we never hand out
+    // more than the app already holds. An explicit option wins for the rare operator who needs
+    // to override.
+    const user = options.user || info.Config?.User || undefined
+
+    const terminal = new Terminal(this.#docker, appName, {...options, user})
+    return terminal.open()
   }
 
   /**

--- a/server/src/Container.js
+++ b/server/src/Container.js
@@ -505,7 +505,7 @@ class Container {
    * @param {string} name - Unique container name
    * @param {Object} options - Configuration options
    * @param {string} options.image - Docker image name
-   * @param {Array} options.ports - Array of port mappings [{host: 3000, container: 80}]
+   * @param {Array} options.ports - Array of published port mappings [{host: 3000, container: 80}]. Proxy-routed entries (host: 'proxy') are ignored.
    * @param {Array} options.volumes - Array of volume mappings [{host: '/path', container: '/data'}]
    * @param {Object} options.env - Environment variables {KEY: 'VALUE'}
    * @param {Array} options.cmd - Command to run (optional)
@@ -530,7 +530,11 @@ class Container {
     const exposedPorts = {}
 
     if (options.ports) {
+      const ports = Odac.server('Ports')
       for (const port of options.ports) {
+        // Defense in depth: a proxy-routed entry has no host binding to publish.
+        if (!ports.isPublished(port)) continue
+
         const portKey = `${port.container}/tcp`
         const bindIp = port.ip || '127.0.0.1'
         portBindings[portKey] = [{HostPort: String(port.host), HostIp: bindIp}]

--- a/server/src/Container.js
+++ b/server/src/Container.js
@@ -505,7 +505,7 @@ class Container {
    * @param {string} name - Unique container name
    * @param {Object} options - Configuration options
    * @param {string} options.image - Docker image name
-   * @param {Array} options.ports - Array of published port mappings [{host: 3000, container: 80}]. Proxy-routed entries (host: 'proxy') are ignored.
+   * @param {Array} options.ports - Array of published port mappings [{host: 3000, container: 80, public: false}]. Proxy-routed entries (host: 'proxy') are ignored. A container port may repeat across entries. Entries bind to 127.0.0.1 unless `public` is true.
    * @param {Array} options.volumes - Array of volume mappings [{host: '/path', container: '/data'}]
    * @param {Object} options.env - Environment variables {KEY: 'VALUE'}
    * @param {Array} options.cmd - Command to run (optional)
@@ -536,8 +536,16 @@ class Container {
         if (!ports.isPublished(port)) continue
 
         const portKey = `${port.container}/tcp`
-        const bindIp = port.ip || '127.0.0.1'
-        portBindings[portKey] = [{HostPort: String(port.host), HostIp: bindIp}]
+        if (ports.isPublic(port)) {
+          log('Publishing %s port %s on every interface (public).', name, port.host)
+        }
+
+        // Append: Docker takes a list of host bindings per container port, so a
+        // single container port may be published on several host ports.
+        const binding = {HostPort: String(port.host), HostIp: ports.bindIp(port)}
+        if (portBindings[portKey]) portBindings[portKey].push(binding)
+        else portBindings[portKey] = [binding]
+
         exposedPorts[portKey] = {}
       }
     }

--- a/server/src/Container/Terminal.js
+++ b/server/src/Container/Terminal.js
@@ -1,0 +1,331 @@
+const nodeCrypto = require('crypto')
+
+const {log, error} = Odac.core('Log', false).init('Container', 'Terminal')
+
+const SESSION_ENV = 'ODAC_TTY_SESSION'
+
+// Pick bash when the image ships it, fall back to sh. `exec` so the shell replaces
+// this probe process and stays the tagged root of the session tree.
+const DEFAULT_SHELL = ['/bin/sh', '-lc', 'command -v bash >/dev/null 2>&1 && exec bash || exec sh']
+
+const DEFAULT_COLS = 80
+const DEFAULT_ROWS = 24
+const MAX_DIMENSION = 1000
+
+const REAP_GRACE_MS = 1000
+const DEFAULT_IDLE_TIMEOUT = 15 * 60 * 1000
+const DEFAULT_MAX_LIFETIME = 4 * 60 * 60 * 1000
+
+/**
+ * Signals every process carrying our session tag.
+ *
+ * Docker exposes no "kill exec" API and `exec.inspect().Pid` lives in the daemon's PID
+ * namespace, unreachable from the odac container. Instead each session tags its exec with
+ * a unique env var; children inherit environ, so one /proc sweep finds the whole tree —
+ * including background jobs, which a process-group kill would miss. The reaping exec is
+ * itself untagged, so it can never signal itself.
+ *
+ * Children first, then the shell — with a pause in between.
+ *
+ * Only a parent can wait() away its dead children, and here that parent is the shell. Kill
+ * the shell first and its dying children reparent onto the container's pid 1, which is the
+ * app rather than an init and never reaps: one zombie per abandoned job, forever. Kill them
+ * in the same breath as the shell and it exits before it can reap them. So: signal every
+ * child (highest pid first — the shell is the oldest and therefore lowest), give it a moment
+ * to collect them, and only then hang up the shell itself.
+ *
+ * The pause is skipped when the shell is alone, which is the common case.
+ *
+ * Must stay a single line: a multi-line `for … done` followed by a newline and `| sort`
+ * parses as `done \n | sort`, a shell syntax error.
+ */
+const reapScript = (tag, signal) =>
+  `pids=$(for p in /proc/[0-9]*; do pid=\${p##*/}; [ -r "$p/environ" ] || continue; ` +
+  `if tr '\\0' '\\n' < "$p/environ" 2>/dev/null | grep -qx "${SESSION_ENV}=${tag}"; then echo "$pid"; fi; ` +
+  `done | sort -rn); ` +
+  `[ -n "$pids" ] || exit 0; ` +
+  `shell=$(echo "$pids" | tail -n 1); others=$(echo "$pids" | sed '$d'); ` +
+  `if [ -n "$others" ]; then for p in $others; do kill -${signal} "$p" 2>/dev/null; done; sleep 1; fi; ` +
+  `kill -${signal} "$shell" 2>/dev/null; true`
+
+const clampDimension = (value, fallback) => {
+  const n = Math.trunc(Number(value))
+  if (!Number.isFinite(n) || n < 1) return fallback
+  return Math.min(n, MAX_DIMENSION)
+}
+
+/**
+ * One interactive shell inside a running container, over a Docker exec with a real TTY.
+ *
+ * Lifecycle: open() → write()/resize() → close(). The session also closes itself when the
+ * shell exits, when input goes idle, or when it outlives maxLifetime.
+ */
+class Terminal {
+  #container
+  #name
+  #tag // secret, ours — never derived from caller input, it lands in a shell command
+  #exec = null
+  #stream = null
+
+  #closing = false
+  #closed = false
+
+  #onData
+  #onExit
+
+  #cols
+  #rows
+  #command
+  #user
+  #env
+  #workdir
+
+  #idleTimeout
+  #maxLifetime
+  #idleTimer = null
+  #lifeTimer = null
+
+  #openedAt = null
+
+  /**
+   * @param {import('dockerode')} docker
+   * @param {string} name - Container name
+   * @param {Object} [options]
+   * @param {function(Buffer): void} [options.onData] - Raw pty output
+   * @param {function(Object): void} [options.onExit] - {reason, exitCode} — fires exactly once
+   * @param {number} [options.cols=80]
+   * @param {number} [options.rows=24]
+   * @param {string[]} [options.command] - Overrides the bash-or-sh probe
+   * @param {string} [options.user] - Exec as this user instead of the image default
+   * @param {string[]} [options.env] - Extra `KEY=value` entries
+   * @param {string} [options.workdir]
+   * @param {number} [options.idleTimeout] - Since last *input*; 0 disables
+   * @param {number} [options.maxLifetime] - Hard cap since open(); 0 disables
+   */
+  constructor(docker, name, options = {}) {
+    this.#name = name
+    this.#container = docker.getContainer(name)
+    this.#tag = nodeCrypto.randomBytes(16).toString('hex')
+
+    this.#onData = options.onData || (() => {})
+    this.#onExit = options.onExit || (() => {})
+
+    this.#cols = clampDimension(options.cols, DEFAULT_COLS)
+    this.#rows = clampDimension(options.rows, DEFAULT_ROWS)
+    this.#command = Array.isArray(options.command) && options.command.length ? options.command : DEFAULT_SHELL
+    this.#user = options.user
+    this.#env = Array.isArray(options.env) ? options.env : []
+    this.#workdir = options.workdir
+
+    this.#idleTimeout = options.idleTimeout ?? DEFAULT_IDLE_TIMEOUT
+    this.#maxLifetime = options.maxLifetime ?? DEFAULT_MAX_LIFETIME
+  }
+
+  get closed() {
+    return this.#closed
+  }
+
+  get container() {
+    return this.#name
+  }
+
+  /**
+   * Creates the exec, attaches, and starts the timers.
+   * @returns {Promise<Terminal>}
+   */
+  async open() {
+    if (this.#exec) throw new Error('Terminal already opened')
+
+    const options = {
+      Cmd: this.#command,
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: true,
+      // Sizing the pty up front avoids a first paint at 0x0.
+      ConsoleSize: [this.#rows, this.#cols],
+      Env: [`${SESSION_ENV}=${this.#tag}`, ...this.#env]
+    }
+    if (this.#user) options.User = this.#user
+    if (this.#workdir) options.WorkingDir = this.#workdir
+
+    this.#exec = await this.#container.exec(options)
+
+    // Tty must be repeated here. dockerode's ExecStart body defaults it to false and the
+    // daemon uses *that* flag to choose raw-vs-multiplexed framing — omit it and the stream
+    // arrives with 8-byte stream headers even though the exec really does own a pty.
+    this.#stream = await this.#exec.start({hijack: true, stdin: true, Tty: true})
+
+    this.#stream.on('data', chunk => this.#onData(chunk))
+    this.#stream.on('end', () => this.close('exited'))
+    this.#stream.on('error', err => {
+      // destroy() during close() surfaces here; only real failures are worth reporting.
+      if (!this.#closing && !this.#closed) {
+        error('Terminal stream error on %s: %s', this.#name, err.message)
+        this.close('error')
+      }
+    })
+
+    this.#armIdleTimer()
+    if (this.#maxLifetime > 0) {
+      this.#lifeTimer = setTimeout(() => this.close('lifetime'), this.#maxLifetime)
+    }
+
+    this.#openedAt = Date.now()
+    // Audit trail: who got a shell where, and as which user. Correlate with the Hub-side
+    // session record for the human behind it.
+    log('[AUDIT] terminal opened: container=%s user=%s', this.#name, this.#user || 'container-default')
+    return this
+  }
+
+  /**
+   * Forwards user input to the pty. Resets the idle timer — output alone must not, or a
+   * chatty process would keep an abandoned session alive forever.
+   * @param {Buffer|string} data
+   * @returns {boolean}
+   */
+  write(data) {
+    if (this.#closed || !this.#stream) return false
+    this.#armIdleTimer()
+    this.#stream.write(data)
+    return true
+  }
+
+  /**
+   * @param {number} cols
+   * @param {number} rows
+   */
+  async resize(cols, rows) {
+    if (this.#closed || !this.#exec) return false
+
+    this.#cols = clampDimension(cols, this.#cols)
+    this.#rows = clampDimension(rows, this.#rows)
+
+    try {
+      await this.#exec.resize({h: this.#rows, w: this.#cols})
+      return true
+    } catch (e) {
+      // The shell can exit between our check and the call; that is not an error worth raising.
+      log('Terminal resize failed on %s: %s', this.#name, e.message)
+      return false
+    }
+  }
+
+  /**
+   * Tears the session down and reaps the process tree. Idempotent; onExit fires once.
+   * @param {string} [reason] - exited | closed | idle | lifetime | error
+   */
+  async close(reason = 'closed') {
+    if (this.#closed || this.#closing) return
+    this.#closing = true
+
+    this.#clearTimers()
+
+    if (this.#stream) {
+      this.#stream.destroy()
+      this.#stream = null
+    }
+
+    // Closing the stream does NOT kill the exec: the shell and its children keep running and
+    // exec.inspect().Running stays true. Reap explicitly, every time.
+    await this.#reap()
+
+    const exitCode = await this.#exitCode()
+
+    this.#closed = true
+    this.#closing = false
+
+    const durationSec = this.#openedAt ? Math.round((Date.now() - this.#openedAt) / 1000) : 0
+    log('[AUDIT] terminal closed: container=%s reason=%s exitCode=%s duration=%ss', this.#name, reason, exitCode, durationSec)
+    this.#onExit({reason, exitCode})
+  }
+
+  /**
+   * SIGHUP, then SIGKILL for whatever ignored it.
+   *
+   * SIGTERM is the wrong signal here: an interactive shell ignores it, so the children die
+   * and the shell is left orphaned. SIGHUP is the real terminal-hangup signal — the shell
+   * runs its traps, exits, and hangs up its jobs.
+   */
+  async #reap() {
+    try {
+      await this.#runInContainer(reapScript(this.#tag, 'HUP'))
+
+      if (!(await this.#isExecRunning())) return
+
+      await new Promise(resolve => setTimeout(resolve, REAP_GRACE_MS))
+      if (!(await this.#isExecRunning())) return
+
+      await this.#runInContainer(reapScript(this.#tag, 'KILL'))
+
+      if (await this.#isExecRunning()) {
+        error('Terminal reap incomplete on %s: session survived SIGKILL', this.#name)
+      }
+    } catch (e) {
+      // A stopped or removed container took the session down with it; nothing left to reap.
+      if (e.statusCode === 404 || e.statusCode === 409) {
+        log('Terminal reap skipped on %s: container gone', this.#name)
+        return
+      }
+      error('Terminal reap failed on %s: %s', this.#name, e.message)
+    }
+  }
+
+  async #isExecRunning() {
+    try {
+      return (await this.#exec.inspect()).Running === true
+    } catch {
+      return false
+    }
+  }
+
+  async #exitCode() {
+    try {
+      const data = await this.#exec.inspect()
+      return data.Running ? null : data.ExitCode
+    } catch {
+      return null
+    }
+  }
+
+  /** Fire-and-forget exec used for reaping. Untagged, so it never matches itself. */
+  async #runInContainer(script) {
+    const options = {
+      Cmd: ['/bin/sh', '-c', script],
+      AttachStdout: true,
+      AttachStderr: true
+    }
+
+    // Reap as the same user the session runs as. The scan reads /proc/<pid>/environ, and
+    // reading a process owned by a *different* uid needs CAP_SYS_PTRACE — which a stock
+    // container's exec doesn't hold — so a root reaper can't even see a nobody shell's environ,
+    // never mind signal it. Matching the user gives both the read (same-uid) and the kill.
+    if (this.#user) options.User = this.#user
+
+    const exec = await this.#container.exec(options)
+    const stream = await exec.start({})
+
+    await new Promise((resolve, reject) => {
+      stream.on('data', () => {}) // drain, or 'end' never fires
+      stream.on('end', resolve)
+      stream.on('error', reject)
+    })
+  }
+
+  #armIdleTimer() {
+    if (this.#idleTimeout <= 0) return
+    if (this.#idleTimer) clearTimeout(this.#idleTimer)
+    this.#idleTimer = setTimeout(() => this.close('idle'), this.#idleTimeout)
+  }
+
+  #clearTimers() {
+    if (this.#idleTimer) clearTimeout(this.#idleTimer)
+    if (this.#lifeTimer) clearTimeout(this.#lifeTimer)
+    this.#idleTimer = null
+    this.#lifeTimer = null
+  }
+}
+
+module.exports = Terminal
+module.exports.SESSION_ENV = SESSION_ENV
+module.exports.DEFAULT_SHELL = DEFAULT_SHELL

--- a/server/src/Hub.js
+++ b/server/src/Hub.js
@@ -3,6 +3,7 @@ const {log, error} = Odac.core('Log', false).init('Hub')
 const nodeCrypto = require('crypto')
 
 const {WebSocketClient, MessageSigner} = require('./Hub/WebSocket')
+const TerminalManager = require('./Hub/Terminal')
 
 const HUB_URL = process.env.ODAC_HUB_URL || 'https://hub.odac.run'
 const HUB_WS_URL = HUB_URL.replace(/^http/, 'ws') + '/ws'
@@ -10,9 +11,14 @@ const HUB_WS_URL = HUB_URL.replace(/^http/, 'ws') + '/ws'
 class Hub {
   #active = false
   #logSubs = new Map()
+  #terminals
 
   constructor() {
     this.ws = new WebSocketClient()
+    this.#terminals = new TerminalManager({
+      wsUrl: HUB_WS_URL,
+      getToken: () => this.#getHubConfig()?.token
+    })
 
     // Commands and Tasks
     this.commands = {
@@ -232,6 +238,12 @@ class Hub {
           return {success: true, message: 'Unsubscribed from build logs'}
         }
       },
+      'terminal.open': {
+        fn: payload => this.#terminals.open(payload)
+      },
+      'terminal.close': {
+        fn: payload => this.#terminals.close(payload)
+      },
       'system.update': {
         fn: () => Odac.server('System').update()
       }
@@ -248,6 +260,7 @@ class Hub {
       onDisconnect: () => {
         log('[Hub] Disconnected from Cloud. Cleaning up active log streams...')
         this.#unsubscribeAllLogs()
+        this.#terminals.closeAll()
       }
     })
   }
@@ -260,6 +273,7 @@ class Hub {
 
   stop() {
     this.#active = false
+    this.#terminals.closeAll()
     this.ws.disconnect()
     log('Hub Service stopped')
   }

--- a/server/src/Hub/Terminal.js
+++ b/server/src/Hub/Terminal.js
@@ -1,0 +1,317 @@
+const {log, error} = Odac.core('Log', false).init('Hub', 'Terminal')
+
+const WebSocketLib = require('ws')
+
+// Hub mints both; they land in a URL path and a header, never in a shell command.
+const ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/
+
+const CONNECT_TIMEOUT = 10000
+
+// Terminal output is unbounded — `cat` a large file and the pty will happily outrun a slow
+// client. Once the socket has this much unflushed, the session is beyond saving: dropping
+// chunks would corrupt the stream, so close it honestly instead of growing the heap.
+const MAX_BUFFERED_BYTES = 8 * 1024 * 1024
+
+const DEFAULTS = {
+  enabled: true,
+  maxSessions: 3,
+  idleTimeout: 15 * 60 * 1000,
+  maxLifetime: 4 * 60 * 60 * 1000,
+  // A shell in a privileged container is effectively a host shell; opening one stays a
+  // deliberate operator decision, never the default — even with terminals enabled.
+  allowPrivileged: false
+}
+
+/**
+ * One terminal session: a dedicated WebSocket to the Hub paired with a container exec.
+ *
+ * The data plane is deliberately kept off the main Hub socket. That socket carries the
+ * control protocol behind a 30s ping/pong liveness check, and a WebSocket is a single TCP
+ * stream — a few megabytes of terminal output would delay the pong and get the agent's whole
+ * Hub connection torn down. It also spares every keystroke an HMAC over canonical JSON.
+ *
+ * Framing on the session socket: binary frames are raw pty bytes, text frames are JSON
+ * control messages. Data therefore needs no envelope at all.
+ */
+class TerminalSession {
+  #id
+  #app
+  #socket = null
+  #terminal = null
+  #closing = false
+  #onClosed
+
+  constructor({id, app, onClosed}) {
+    this.#id = id
+    this.#app = app
+    this.#onClosed = onClosed
+  }
+
+  get id() {
+    return this.#id
+  }
+
+  get app() {
+    return this.#app
+  }
+
+  /**
+   * Opens the container exec first, then dials the Hub.
+   *
+   * That order matters: a bad app name or a stopped container has to fail before we claim a
+   * session slot on the Hub side, so the failure surfaces in the command response rather
+   * than as a socket that opens and immediately dies.
+   */
+  async open({url, token, ticket, cols, rows, idleTimeout, maxLifetime, allowPrivileged}) {
+    this.#terminal = await Odac.server('Container').createTerminalSession(this.#app, {
+      cols,
+      rows,
+      idleTimeout,
+      maxLifetime,
+      allowPrivileged,
+      onData: chunk => this.#send(chunk),
+      onExit: info => this.#handleExit(info)
+    })
+
+    try {
+      await this.#dial(url, token, ticket)
+    } catch (e) {
+      await this.#terminal.close('error')
+      throw e
+    }
+
+    log('[Terminal] Session %s attached to %s', this.#id, this.#app)
+  }
+
+  #dial(url, token, ticket) {
+    return new Promise((resolve, reject) => {
+      this.#socket = new WebSocketLib(url, {
+        rejectUnauthorized: true,
+        headers: {Authorization: `Bearer ${token}`, 'X-Odac-Ticket': ticket}
+      })
+
+      let settled = false
+      const timer = setTimeout(() => {
+        settled = true
+        this.#socket.terminate()
+        reject(new Error('Terminal socket timed out'))
+      }, CONNECT_TIMEOUT)
+
+      this.#socket.once('open', () => {
+        settled = true
+        clearTimeout(timer)
+        resolve()
+      })
+
+      // A persistent listener, not once(): 'ws' emits 'error' before 'close' at any point in
+      // the socket's life, and an 'error' with no listener takes the process down with it.
+      this.#socket.on('error', err => {
+        if (settled) {
+          error('[Terminal] Session %s socket error: %s', this.#id, err.message)
+          return
+        }
+        settled = true
+        clearTimeout(timer)
+        reject(err)
+      })
+
+      this.#socket.on('message', (data, isBinary) => this.#handleMessage(data, isBinary))
+      this.#socket.on('close', () => this.close('socket'))
+    })
+  }
+
+  #handleMessage(data, isBinary) {
+    // Keystrokes are the overwhelming majority; keep them on the cheapest path.
+    if (isBinary) {
+      this.#terminal?.write(data)
+      return
+    }
+
+    let message
+    try {
+      message = JSON.parse(data.toString())
+    } catch {
+      log('[Terminal] Session %s sent malformed control frame', this.#id)
+      return
+    }
+
+    switch (message.type) {
+      case 'resize':
+        this.#terminal?.resize(message.cols, message.rows)
+        break
+      case 'close':
+        this.close('remote')
+        break
+      default:
+        log('[Terminal] Session %s sent unknown control frame: %s', this.#id, message.type)
+    }
+  }
+
+  #send(chunk) {
+    if (this.#socket?.readyState !== WebSocketLib.OPEN) return
+
+    if (this.#socket.bufferedAmount > MAX_BUFFERED_BYTES) {
+      error('[Terminal] Session %s outran its socket, closing', this.#id)
+      this.close('overflow')
+      return
+    }
+
+    this.#socket.send(chunk, {binary: true})
+  }
+
+  #control(payload) {
+    if (this.#socket?.readyState !== WebSocketLib.OPEN) return
+    this.#socket.send(JSON.stringify(payload))
+  }
+
+  /** The shell ended on its own (or a timer reaped it): tell the Hub, then hang up. */
+  #handleExit({reason, exitCode}) {
+    this.#control({type: 'exit', reason, exitCode})
+    this.close(reason)
+  }
+
+  /**
+   * Idempotent, and reachable from both ends: the socket closing must reap the exec, and the
+   * exec exiting must close the socket.
+   * @param {string} [reason]
+   */
+  async close(reason = 'closed') {
+    if (this.#closing) return
+    this.#closing = true
+
+    const terminal = this.#terminal
+    const socket = this.#socket
+    this.#terminal = null
+    this.#socket = null
+
+    if (socket) {
+      socket.removeAllListeners('close')
+      if (socket.readyState === WebSocketLib.OPEN) socket.close()
+      else socket.terminate()
+    }
+
+    if (terminal && !terminal.closed) {
+      try {
+        await terminal.close(reason)
+      } catch (e) {
+        error('[Terminal] Session %s failed to close cleanly: %s', this.#id, e.message)
+      }
+    }
+
+    log('[Terminal] Session %s detached from %s (%s)', this.#id, this.#app, reason)
+    this.#onClosed?.(this.#id)
+  }
+}
+
+/**
+ * Owns the live sessions and enforces the per-agent limits.
+ */
+class TerminalManager {
+  #wsUrl
+  #getToken
+  #sessions = new Map()
+
+  /**
+   * @param {Object} options
+   * @param {string} options.wsUrl - Hub WebSocket base, e.g. wss://hub.odac.run/ws
+   * @param {function(): string|undefined} options.getToken
+   */
+  constructor({wsUrl, getToken}) {
+    this.#wsUrl = wsUrl
+    this.#getToken = getToken
+  }
+
+  get count() {
+    return this.#sessions.size
+  }
+
+  #settings() {
+    const configured = Odac.core('Config').config.hub?.terminal || {}
+    return {...DEFAULTS, ...configured}
+  }
+
+  /**
+   * Handles a `terminal.open` command from the Hub.
+   * @returns {Promise<Object>} {success, message, data?}
+   */
+  async open(payload = {}) {
+    const settings = this.#settings()
+
+    if (!settings.enabled) {
+      return {success: false, message: 'Terminal access is disabled'}
+    }
+
+    const {app, sessionId, ticket} = payload
+
+    // The Hub is authenticated, but a bug or a compromise there must not be able to steer
+    // these into the URL. Both are opaque tokens; anything else is a red flag.
+    if (!ID_PATTERN.test(sessionId || '') || !ID_PATTERN.test(ticket || '')) {
+      return {success: false, message: 'Invalid session id or ticket'}
+    }
+
+    if (!app || typeof app !== 'string') {
+      return {success: false, message: 'Missing app'}
+    }
+
+    if (this.#sessions.has(sessionId)) {
+      return {success: false, message: 'Session already open'}
+    }
+
+    if (this.#sessions.size >= settings.maxSessions) {
+      return {success: false, message: `Too many terminal sessions (max ${settings.maxSessions})`}
+    }
+
+    const token = this.#getToken()
+    if (!token) return {success: false, message: 'Not authenticated'}
+
+    const session = new TerminalSession({id: sessionId, app, onClosed: id => this.#sessions.delete(id)})
+
+    // Reserve the slot before the awaits below, or concurrent opens both see room.
+    this.#sessions.set(sessionId, session)
+
+    try {
+      await session.open({
+        url: `${this.#wsUrl}/terminal/${sessionId}`,
+        token,
+        ticket,
+        cols: payload.cols,
+        rows: payload.rows,
+        idleTimeout: settings.idleTimeout,
+        maxLifetime: settings.maxLifetime,
+        allowPrivileged: settings.allowPrivileged
+      })
+    } catch (e) {
+      this.#sessions.delete(sessionId)
+      error('[Terminal] Session %s failed to open on %s: %s', sessionId, app, e.message)
+      return {success: false, message: e.message}
+    }
+
+    return {success: true, message: 'Terminal session opened', data: {sessionId, app}}
+  }
+
+  /**
+   * Handles a `terminal.close` command from the Hub.
+   */
+  async close(payload = {}) {
+    const session = this.#sessions.get(payload.sessionId)
+    if (!session) return {success: false, message: 'Unknown session'}
+
+    await session.close('command')
+    return {success: true, message: 'Terminal session closed'}
+  }
+
+  /**
+   * Tears every session down. The Hub connection dropping means nobody is watching, and an
+   * unattended shell must not outlive it.
+   */
+  async closeAll() {
+    if (this.#sessions.size === 0) return
+
+    log('[Terminal] Closing %d active session(s)', this.#sessions.size)
+    await Promise.all([...this.#sessions.values()].map(session => session.close('hub_disconnected')))
+    this.#sessions.clear()
+  }
+}
+
+module.exports = TerminalManager
+module.exports.TerminalSession = TerminalSession

--- a/server/src/Ports.js
+++ b/server/src/Ports.js
@@ -1,0 +1,70 @@
+'use strict'
+
+/**
+ * Shared semantics for app port mappings, used by App (Docker publishing)
+ * and Proxy (backend routing).
+ *
+ * A port entry is `{host, container}`. `container` is always the port the
+ * process listens on inside the container; `host` decides how it is exposed:
+ *
+ *   - `<number>` -> published on the host through Docker PortBindings.
+ *   - `'proxy'`  -> not published; ODAC's reverse proxy routes to the container
+ *                   port over the internal Docker network.
+ *
+ * `'proxy'` is the explicit spelling of what used to be an absent `host`.
+ * Making it explicit lets the dashboard show who owns a port instead of
+ * inferring ownership from a missing field.
+ *
+ * `'auto'` is an input-only value, resolved to a free host port before the
+ * entry is persisted.
+ */
+const PROXY = 'proxy'
+
+class Ports {
+  /** Sentinel `host` value marking an entry as reverse-proxy routed. */
+  get PROXY() {
+    return PROXY
+  }
+
+  /**
+   * True when the entry is routed by the ODAC proxy rather than published.
+   * A missing `host` counts as proxy so configs written before the sentinel
+   * existed keep resolving correctly.
+   *
+   * @param {{host?: number|string, container?: number}} entry - Port mapping
+   * @returns {boolean}
+   */
+  isProxy(entry) {
+    return !!entry && (!entry.host || entry.host === PROXY)
+  }
+
+  /**
+   * True when the entry must be handed to Docker as a host port binding.
+   *
+   * @param {{host?: number|string, container?: number}} entry - Port mapping
+   * @returns {boolean}
+   */
+  isPublished(entry) {
+    return !!entry && !this.isProxy(entry)
+  }
+
+  /**
+   * Rewrites legacy entries in place to the canonical shape.
+   * Why: entries persisted before the sentinel omit `host` entirely, and both
+   * the dashboard and `setPorts` validation now expect it to be present.
+   *
+   * @param {Array<{host?: number|string, container?: number}>} ports - Port mappings
+   * @returns {Array} The same array, normalized in place
+   */
+  normalize(ports) {
+    if (!Array.isArray(ports)) return ports
+
+    for (const entry of ports) {
+      if (entry && !entry.host) entry.host = PROXY
+    }
+
+    return ports
+  }
+}
+
+module.exports = new Ports()

--- a/server/src/Ports.js
+++ b/server/src/Ports.js
@@ -4,8 +4,8 @@
  * Shared semantics for app port mappings, used by App (Docker publishing)
  * and Proxy (backend routing).
  *
- * A port entry is `{host, container}`. `container` is always the port the
- * process listens on inside the container; `host` decides how it is exposed:
+ * A port entry is `{host, container, public?}`. `container` is always the port
+ * the process listens on inside the container; `host` decides how it is exposed:
  *
  *   - `<number>` -> published on the host through Docker PortBindings.
  *   - `'proxy'`  -> not published; ODAC's reverse proxy routes to the container
@@ -17,8 +17,38 @@
  *
  * `'auto'` is an input-only value, resolved to a free host port before the
  * entry is persisted.
+ *
+ * The same container port may appear on several entries: the proxy reaches it
+ * over the container network while Docker publishes it on the host, and the two
+ * paths never meet.
+ *
+ * `public` only applies to published entries and decides the bind address:
+ *
+ *   - absent/false -> bound to 127.0.0.1. Reachable by the proxy and by other
+ *                     processes on this host, by nothing else.
+ *   - true         -> bound to every interface, so other machines can reach it.
+ *
+ * Publishing is opt-in per entry because a published port never traverses the
+ * host firewall's INPUT chain: Docker's DNAT rewrites the destination in
+ * nat/PREROUTING, so the routing decision forwards the packet to the container
+ * and it only ever meets the FORWARD chain, where ufw has no rules. A public
+ * entry is reachable from the internet even when ufw says otherwise, so it must
+ * never become the default for an entry that did not ask for it.
+ *
+ * `auto` marks a container port ODAC guessed rather than one the user or a
+ * recipe declared. Only a guess may be corrected by runtime auto-discovery.
  */
 const PROXY = 'proxy'
+
+/** Bind address for a published-but-not-public entry. */
+const LOOPBACK = '127.0.0.1'
+
+/**
+ * Bind address for a public entry. Empty means "every interface" to Docker,
+ * which resolves it to 0.0.0.0 plus [::] when the host has IPv6. Naming the
+ * families explicitly instead would fail container create on IPv6-less hosts.
+ */
+const ANY = ''
 
 class Ports {
   /** Sentinel `host` value marking an entry as reverse-proxy routed. */
@@ -49,9 +79,93 @@ class Ports {
   }
 
   /**
+   * True when the entry is published on every interface rather than loopback.
+   * Proxy-routed entries are never public: they have no host binding at all.
+   *
+   * @param {{host?: number|string, public?: boolean}} entry - Port mapping
+   * @returns {boolean}
+   */
+  isPublic(entry) {
+    return this.isPublished(entry) && entry.public === true
+  }
+
+  /**
+   * The `HostIp` to hand Docker for a published entry.
+   *
+   * @param {{host?: number|string, public?: boolean}} entry - Port mapping
+   * @returns {string} '' for every interface, '127.0.0.1' otherwise
+   */
+  bindIp(entry) {
+    return this.isPublic(entry) ? ANY : LOOPBACK
+  }
+
+  /**
+   * True when ODAC guessed this entry's container port instead of being told it.
+   * Only a guess may be rewritten by runtime auto-discovery.
+   *
+   * @param {{auto?: boolean}} entry - Port mapping
+   * @returns {boolean}
+   */
+  isAuto(entry) {
+    return !!entry && entry.auto === true
+  }
+
+  /**
+   * The entry the reverse proxy routes, and the app's main container port.
+   * Why not `ports[0]`: an app may publish a port and also sit behind the proxy,
+   * and the dashboard does not guarantee an order between the two.
+   *
+   * Falls back to the first entry when nothing is proxy-routed, so an app that
+   * only publishes still resolves a backend.
+   *
+   * @param {Array<{host?: number|string, container?: number}>} ports - Port mappings
+   * @returns {object|undefined} The primary entry, or undefined when there are none
+   */
+  primary(ports) {
+    if (!Array.isArray(ports) || ports.length === 0) return undefined
+
+    return ports.find(entry => this.isProxy(entry)) || ports[0]
+  }
+
+  /**
+   * Builds the entry for a container port ODAC inferred (image EXPOSE, or the
+   * 3000 default). Centralized so a guess can never be persisted without its
+   * `auto` marker, which is what keeps auto-discovery off declared ports.
+   *
+   * @param {number} containerPort - The inferred container port
+   * @returns {{host: string, container: number, auto: boolean}}
+   */
+  discovered(containerPort) {
+    return {host: PROXY, container: containerPort, auto: true}
+  }
+
+  /**
+   * Coerces a `public` flag that may have crossed a JSON or form boundary.
+   * Why: Hub sends port entries over a WebSocket and the dashboard may serialize
+   * the checkbox as a string, so `'false'` must not read as truthy.
+   *
+   * @param {*} value - Raw flag from an untrusted payload
+   * @returns {boolean|null} The flag, or null when the value is not a boolean
+   */
+  parsePublic(value) {
+    if (value === undefined || value === null || value === '') return false
+    if (typeof value === 'boolean') return value
+    if (value === 'true') return true
+    if (value === 'false') return false
+
+    return null
+  }
+
+  /**
    * Rewrites legacy entries in place to the canonical shape.
    * Why: entries persisted before the sentinel omit `host` entirely, and both
    * the dashboard and `setPorts` validation now expect it to be present.
+   *
+   * A legacy proxy entry is also marked as a guess. No shipped surface let a
+   * proxy container port be chosen by hand, so every one of them was inferred by
+   * ODAC — and marking them keeps auto-discovery correcting them exactly as it
+   * did before the marker existed. Only entries loaded from disk pass through
+   * here, so a port the user sets from now on is never marked.
    *
    * @param {Array<{host?: number|string, container?: number}>} ports - Port mappings
    * @returns {Array} The same array, normalized in place
@@ -60,7 +174,10 @@ class Ports {
     if (!Array.isArray(ports)) return ports
 
     for (const entry of ports) {
-      if (entry && !entry.host) entry.host = PROXY
+      if (entry && !entry.host) {
+        entry.host = PROXY
+        entry.auto = true
+      }
     }
 
     return ports

--- a/server/src/Proxy.js
+++ b/server/src/Proxy.js
@@ -92,10 +92,11 @@ class OdacProxy {
     let useInternal = false
 
     if (app.ports && app.ports.length > 0) {
-      if (app.ports[0].host) {
-        port = parseInt(app.ports[0].host)
-      } else if (app.ports[0].container) {
-        port = parseInt(app.ports[0].container)
+      const primary = app.ports[0]
+      if (Odac.server('Ports').isPublished(primary)) {
+        port = parseInt(primary.host)
+      } else if (primary.container) {
+        port = parseInt(primary.container)
         useInternal = true
       }
     } else if (app.port) {
@@ -515,7 +516,7 @@ class OdacProxy {
 
     // Safety: If we have container apps, wait for Docker to be available
     // to prevent falling back to 127.0.0.1 during startup.
-    const hasContainerApps = apps.some(a => a.ports?.some(p => p.container && !p.host))
+    const hasContainerApps = apps.some(a => a.ports?.some(p => p.container && Odac.server('Ports').isProxy(p)))
     if (hasContainerApps && retryCount === 0) {
       const container = Odac.server('Container')
       let waits = 0

--- a/server/src/Proxy.js
+++ b/server/src/Proxy.js
@@ -91,9 +91,11 @@ class OdacProxy {
     let host = '127.0.0.1'
     let useInternal = false
 
-    if (app.ports && app.ports.length > 0) {
-      const primary = app.ports[0]
-      if (Odac.server('Ports').isPublished(primary)) {
+    const ports = Odac.server('Ports')
+    const primary = ports.primary(app.ports)
+
+    if (primary) {
+      if (ports.isPublished(primary)) {
         port = parseInt(primary.host)
       } else if (primary.container) {
         port = parseInt(primary.container)

--- a/server/src/System/Updater.js
+++ b/server/src/System/Updater.js
@@ -16,6 +16,11 @@ const UPDATE_CONTAINER_NAME = 'odac-update'
 const BACKUP_CONTAINER_NAME = 'odac-backup'
 const RUNNER_IMAGE = 'docker:cli'
 
+// Env vars the update cycle injects into the incoming container. They describe a
+// single handover, so they are stripped from the inherited env before the next
+// one is built — otherwise every update appends another copy.
+const UPDATE_ENV_KEYS = ['ODAC_UPDATE_MODE', 'ODAC_INSTANCE_ID', 'ODAC_PREVIOUS_INSTANCE_ID', 'ODAC_UPDATE_SOCKET_PATH', 'ODAC_LOG_NAME']
+
 class Updater {
   #updating = false
   #isUpdateMode = false
@@ -86,6 +91,14 @@ class Updater {
     if (process.env.ODAC_LOG_NAME && process.env.ODAC_LOG_NAME.includes('odac-update')) {
       console.log('ODAC_CMD:SWITCH_LOGS')
     }
+
+    // Self-heal a host left inconsistent by a crashed or rolled-back update.
+    // Identity first: #ensureRestartPolicy() looks the container up by name, so
+    // the name has to be ours again before the policy can be repaired. Both are
+    // idempotent and cheap — a no-op on healthy hosts.
+    await this.#ensureIdentity()
+    await this.#ensureRestartPolicy()
+
     this.#triggerReady()
   }
 
@@ -326,7 +339,7 @@ class Updater {
       const createOptions = {
         name: newName,
         Image: this.#image,
-        Env: env.filter(e => !e.startsWith('ODAC_UPDATE_MODE=') && !e.startsWith('ODAC_INSTANCE_ID=')),
+        Env: env.filter(e => !UPDATE_ENV_KEYS.some(k => e.startsWith(`${k}=`))),
         HostConfig: {
           Binds: binds,
           Privileged: true,
@@ -449,42 +462,72 @@ class Updater {
 
       // Monitoring: If socket closes before handover completion, Rollback!
       socket.on('close', async () => {
-        if (!handoverCompleted) {
-          log('CRITICAL: New container disconnected prematurely! Initiating ROLLBACK...')
-          try {
-            await this.#fetchContainerLogs(UPDATE_CONTAINER_NAME)
+        if (handoverCompleted) return
 
-            // Restart services immediately
-            if (!servicesRestarted) {
-              log('Restarting services for rollback...')
-              servicesRestarted = true
-              Odac.server('System').init() // Restart all services
-              log('Services restarted successfully')
-            }
+        log('CRITICAL: New container disconnected prematurely! Initiating ROLLBACK...')
 
-            // Clean up failed containers
-            try {
-              const newOne = this.#docker.getContainer(CONTAINER_NAME)
-              await newOne.remove({force: true})
-              log('Failed new container removed.')
-            } catch {
-              try {
-                const updateOne = this.#docker.getContainer(UPDATE_CONTAINER_NAME)
-                await updateOne.remove({force: true})
-              } catch {
-                /* Ignore */
-              }
-            }
-
-            // Restore name
-            const myName = BACKUP_CONTAINER_NAME
-            const me = this.#docker.getContainer(myName)
-            await me.rename({name: CONTAINER_NAME})
-            log('Rollback successful: Restored self to "odac". Continuing operations.')
-          } catch (err) {
-            error('Rollback failed: %s', err.message)
-          }
+        // Tear this listener down before anything else. The rollback restarts our
+        // services through System.init(), which re-enters Updater.init(); if the
+        // socket were still listening, init() would find it, handshake with *this*
+        // process and drive takeOver() inside the old container — renaming us to
+        // 'odac-backup' and leaving no container named 'odac' at all.
+        clearTimeout(globalTimeout)
+        try {
+          server.close()
+        } catch {
+          /* Ignore */
         }
+        try {
+          fs.unlinkSync(socketPath)
+        } catch {
+          /* Ignore */
+        }
+
+        try {
+          await this.#fetchContainerLogs(UPDATE_CONTAINER_NAME)
+
+          // Establish who we are before removing anything: a rollback must never
+          // force-remove the container it is running inside. Before takeOver we
+          // still own 'odac' and the failed container is 'odac-update'; after
+          // takeOver we are 'odac-backup' and the failed one has claimed 'odac'.
+          const selfName = await this.#resolveSelfName()
+          const failedName = selfName === BACKUP_CONTAINER_NAME ? CONTAINER_NAME : UPDATE_CONTAINER_NAME
+
+          // Restart services immediately
+          if (!servicesRestarted) {
+            log('Restarting services for rollback...')
+            servicesRestarted = true
+            await Odac.server('System').init() // Restart all services
+            log('Services restarted successfully')
+          }
+
+          // Clean up the failed container
+          try {
+            await this.#docker.getContainer(failedName).remove({force: true})
+            log('Failed new container removed: %s', failedName)
+          } catch (e) {
+            if (e.statusCode !== 404) log('Warning: could not remove %s: %s', failedName, e.message)
+          }
+
+          // Restore our name, if takeOver already renamed us away from it
+          try {
+            await this.#docker.getContainer(BACKUP_CONTAINER_NAME).rename({name: CONTAINER_NAME})
+            log('Restored self to "%s".', CONTAINER_NAME)
+          } catch (e) {
+            if (e.statusCode !== 404) error('Failed to restore name: %s', e.message)
+          }
+
+          // takeOver() revoked our restart policy on the way out; take it back.
+          await this.#ensureRestartPolicy()
+          log('Rollback successful. Continuing operations.')
+        } catch (err) {
+          error('Rollback failed: %s', err.message)
+        }
+
+        // Unblock execute(), which is still awaiting the completion promise.
+        // Without this it hangs until the 5-minute global timeout, and #updating
+        // stays true — blocking every later update attempt.
+        rejectCompletion(new Error('Rolled back: new container disconnected prematurely'))
       })
 
       socket.on('data', async data => {
@@ -563,6 +606,115 @@ class Updater {
     })
   }
 
+  /**
+   * Best-effort resolution of the name of the container we are running inside.
+   *
+   * The usual "hostname is the container id" trick is useless here: the update
+   * container runs with NetworkMode 'host', so its hostname is the host's. We
+   * instead read the id out of the paths Docker injects into our mount table and
+   * cgroup, and fall back to "whichever update-cycle container is running".
+   *
+   * @returns {Promise<string|null>} Container name without the leading slash.
+   */
+  async #resolveSelfName() {
+    const probes = [
+      ['/proc/self/mountinfo', /\/docker\/containers\/([0-9a-f]{64})/],
+      ['/proc/self/cgroup', /[-/]docker[-/]([0-9a-f]{64})/]
+    ]
+
+    for (const [file, pattern] of probes) {
+      try {
+        const match = fs.readFileSync(file, 'utf8').match(pattern)
+        if (!match) continue
+        const info = await this.#docker.getContainer(match[1]).inspect()
+        return info.Name.replace(/^\//, '')
+      } catch {
+        /* Probe unavailable on this kernel/storage driver; try the next */
+      }
+    }
+
+    // Fallback: the live ODAC process necessarily inhabits one of the
+    // update-cycle containers, and only one of them is running — us.
+    for (const name of [CONTAINER_NAME, BACKUP_CONTAINER_NAME, UPDATE_CONTAINER_NAME]) {
+      try {
+        const info = await this.#docker.getContainer(name).inspect()
+        if (info.State?.Running) return name
+      } catch {
+        /* Not this one */
+      }
+    }
+
+    return null
+  }
+
+  /**
+   * Reclaims the 'odac' container name when a crashed or rolled-back update left
+   * it unowned.
+   *
+   * execute() resolves the current container strictly by name, so a host stranded
+   * under the name 'odac-backup' can never self-update again — every attempt dies
+   * on a 404 before it does anything. Reclaiming the name is what makes such a
+   * host recoverable without an operator running `docker rename` by hand.
+   */
+  async #ensureIdentity() {
+    if (!fs.existsSync('/.dockerenv')) return
+
+    try {
+      await this.#docker.getContainer(CONTAINER_NAME).inspect()
+      return // The name is owned; nothing to reclaim.
+    } catch (e) {
+      if (e.statusCode !== 404) {
+        error('Failed to inspect %s: %s', CONTAINER_NAME, e.message)
+        return
+      }
+    }
+
+    const selfName = await this.#resolveSelfName()
+    if (!selfName || selfName === CONTAINER_NAME) {
+      error('No container owns "%s" and self-identification failed. Rename manually.', CONTAINER_NAME)
+      return
+    }
+
+    try {
+      await this.#docker.getContainer(selfName).rename({name: CONTAINER_NAME})
+      log('Identity reclaimed: "%s" renamed to "%s".', selfName, CONTAINER_NAME)
+    } catch (e) {
+      error('Failed to reclaim identity from "%s": %s', selfName, e.message)
+    }
+  }
+
+  /**
+   * Ensures the live 'odac' container carries a persistent restart policy.
+   *
+   * The zero-downtime path deliberately creates the incoming container with
+   * RestartPolicy 'no' so Docker cannot resurrect it if the handover fails.
+   * Once that container renames itself to 'odac' it becomes the production
+   * instance and must adopt the persistent policy — `docker rename` moves the
+   * name, not the HostConfig. Without this the host reboots and 'odac' stays
+   * down while every other container comes back up.
+   *
+   * Only a missing/'no' policy is repaired, so an operator who deliberately
+   * chose 'always' keeps their choice.
+   */
+  async #ensureRestartPolicy() {
+    // Guard: outside a container there is no 'odac' container that is us.
+    if (!fs.existsSync('/.dockerenv')) return
+
+    try {
+      const container = this.#docker.getContainer(CONTAINER_NAME)
+      const info = await container.inspect()
+      const current = info.HostConfig?.RestartPolicy?.Name || 'no'
+
+      if (current !== 'no') return
+
+      await container.update({RestartPolicy: {Name: 'unless-stopped'}})
+      log('Restart policy repaired: "no" -> "unless-stopped"')
+    } catch (e) {
+      if (e.statusCode === 404) return
+      error('Failed to ensure restart policy: %s', e.message)
+    }
+  }
+
   async #selfDestruct() {
     log('Old container mission complete. Stopping overlap services and exiting.')
 
@@ -622,11 +774,37 @@ class Updater {
       }
     }
 
-    // 3. Rename self
+    // 3. Revoke the backup's restart policy *before* granting our own.
+    //
+    // Invariant: at most one container may carry a persistent restart policy at
+    // any instant. Proxy/DNS/Mail bind with SO_REUSEPORT, so two ODAC instances
+    // resurrected by Docker after a host reboot would not collide on ports —
+    // they would silently split traffic, run two Hub connections and two ACME
+    // clients. selfDestruct() also revokes this, but it only runs ~12s later
+    // after the stability check; a hard reboot inside that window must not find
+    // two auto-starting containers.
+    //
+    // The cost is a millisecond-wide gap where no container auto-starts. That
+    // is recoverable with `docker start odac` (init() then repairs the policy);
+    // a split brain is not.
+    try {
+      const backup = this.#docker.getContainer(backupName)
+      await backup.update({RestartPolicy: {Name: 'no'}})
+      log('Backup restart policy revoked.')
+    } catch (e) {
+      if (e.statusCode !== 404) error('Failed to revoke backup restart policy: %s', e.message)
+    }
+
+    // 4. Rename self
     try {
       const me = this.#docker.getContainer(UPDATE_CONTAINER_NAME)
       await me.rename({name: targetName})
       log('Renamed self to %s', targetName)
+
+      // 5. Adopt the persistent restart policy. Must happen *after* the rename:
+      // until we own the 'odac' name a failed handover should stay dead rather
+      // than be restarted by Docker as a half-migrated instance.
+      await this.#ensureRestartPolicy()
     } catch (e) {
       error('Failed to rename self: %s', e.message)
     }
@@ -689,6 +867,14 @@ class Updater {
         } else if (message === 'HANDOVER_COMPLETE') {
           clearTimeout(timeout)
           log('Update completed successfully.')
+
+          // We are the live instance now, not an updater. The container keeps
+          // ODAC_UPDATE_MODE=true in its env for the rest of its life (env cannot
+          // be rewritten on a running container), and Proxy/DNS/Mail read it on
+          // every start() to decide whether to adopt an existing process. Clear it
+          // in-process so a later restart adopts instead of blindly respawning.
+          delete process.env.ODAC_UPDATE_MODE
+
           // Signal Watchdog to switch to standard logs
           console.log('ODAC_CMD:SWITCH_LOGS')
           socket.end()

--- a/test/server/App.test.js
+++ b/test/server/App.test.js
@@ -25,12 +25,14 @@ describe('App', () => {
   let mockConfig
   let mockRunApp
   let mockCloneRepo
+  let mockGetListeningPorts
 
   beforeEach(() => {
     // Reset config for each test
     mockConfig = {}
     mockRunApp = jest.fn()
     mockCloneRepo = jest.fn()
+    mockGetListeningPorts = jest.fn(() => [3000]) // Default: pass the readiness probe
 
     // Mock global translation
     global.__ = msg => msg
@@ -52,6 +54,9 @@ describe('App', () => {
         return {}
       }),
       server: jest.fn(module => {
+        if (module === 'Ports') {
+          return require('../../server/src/Ports')
+        }
         if (module === 'Container') {
           return {
             available: true,
@@ -66,7 +71,7 @@ describe('App', () => {
             getStats: jest.fn(),
             getStatus: jest.fn(() => Promise.resolve({running: false, restarts: 0})),
             getIP: jest.fn(() => '10.0.0.5'), // Mock IP to prevent infinite loop
-            getListeningPorts: jest.fn(() => [3000]), // Mock to pass readiness probe
+            getListeningPorts: mockGetListeningPorts,
             remove: jest.fn(),
             fetchRepo: jest.fn(),
             getImageExposedPorts: jest.fn(() => []),
@@ -1143,6 +1148,322 @@ describe('App', () => {
       })
       expect(result.success).toBe(false)
       expect(result.message).toMatch(/Missing template name/)
+    })
+  })
+
+  describe('setPorts()', () => {
+    beforeEach(() => {
+      mockConfig.apps = [{id: 1, name: 'web', type: 'container', image: 'nginx', ports: [{host: 'proxy', container: 3000}]}]
+    })
+
+    const ports = () => mockConfig.apps[0].ports
+
+    test('should reject an unknown app', async () => {
+      const result = await App.setPorts('ghost', [{host: 'proxy', container: 3000}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/not found/)
+    })
+
+    test('should reject a non-array payload', async () => {
+      const result = await App.setPorts('web', {host: 'proxy', container: 3000})
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Expected an array/)
+    })
+
+    test('should reject an entry with a missing container port', async () => {
+      const result = await App.setPorts('web', [{host: 8080}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/must have a container port/)
+    })
+
+    test('should reject an entry with an empty container port', async () => {
+      const result = await App.setPorts('web', [{host: 8080, container: ''}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/must have a container port/)
+    })
+
+    test('should reject an entry with a missing host', async () => {
+      const result = await App.setPorts('web', [{container: 3000}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/must have a host port/)
+    })
+
+    test('should reject an entry with an empty host', async () => {
+      const result = await App.setPorts('web', [{host: '', container: 3000}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/must have a host port/)
+    })
+
+    test('should reject an out-of-range host port', async () => {
+      const result = await App.setPorts('web', [{host: 70000, container: 3000}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Invalid host port/)
+    })
+
+    test('should reject an out-of-range container port', async () => {
+      const result = await App.setPorts('web', [{host: 8080, container: 0}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Invalid container port/)
+    })
+
+    test('should reject a garbage host value', async () => {
+      const result = await App.setPorts('web', [{host: 'internal', container: 3000}])
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Invalid host port/)
+    })
+
+    test('should not mutate the app when validation fails', async () => {
+      await App.setPorts('web', [{container: 3000}])
+      expect(ports()).toEqual([{host: 'proxy', container: 3000}])
+    })
+
+    test('should accept the proxy sentinel and keep the port off Docker', async () => {
+      const result = await App.setPorts('web', [{host: 'proxy', container: 8000}])
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([{host: 'proxy', container: 8000}])
+    })
+
+    test('should accept a published host binding', async () => {
+      const result = await App.setPorts('web', [{host: 8080, container: 3000}])
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([{host: 8080, container: 3000}])
+    })
+
+    test('should coerce string ports to numbers so readiness probes compare correctly', async () => {
+      await App.setPorts('web', [{host: '8080', container: '3000'}])
+
+      expect(ports()).toEqual([{host: 8080, container: 3000}])
+    })
+
+    test('should resolve an auto host port', async () => {
+      await App.setPorts('web', [{host: 'auto', container: 3000}])
+
+      expect(ports()[0].host).toBeGreaterThanOrEqual(30000)
+      expect(ports()[0].container).toBe(3000)
+    })
+
+    test('should support mixing published and proxy-routed entries', async () => {
+      const result = await App.setPorts('web', [
+        {host: 'proxy', container: 3000},
+        {host: 9000, container: 9000}
+      ])
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([
+        {host: 'proxy', container: 3000},
+        {host: 9000, container: 9000}
+      ])
+    })
+
+    test('should reject a second proxy-routed entry', async () => {
+      const result = await App.setPorts('web', [
+        {host: 'proxy', container: 3000},
+        {host: 'proxy', container: 4000}
+      ])
+
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Only one port may be routed by the proxy/)
+    })
+
+    test('should reject duplicate container ports', async () => {
+      const result = await App.setPorts('web', [
+        {host: 8080, container: 3000},
+        {host: 9090, container: 3000}
+      ])
+
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Duplicate container port/)
+    })
+
+    test('should reject duplicate host ports', async () => {
+      const result = await App.setPorts('web', [
+        {host: 8080, container: 3000},
+        {host: 8080, container: 4000}
+      ])
+
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Duplicate host port/)
+    })
+
+    test('should resolve two auto host ports to distinct ports', async () => {
+      const result = await App.setPorts('web', [
+        {host: 'auto', container: 3000},
+        {host: 'auto', container: 4000}
+      ])
+
+      expect(result.success).toBe(true)
+      expect(ports()[0].host).not.toBe(ports()[1].host)
+    })
+
+    test('should not leave the app mutated when a collision is rejected', async () => {
+      await App.setPorts('web', [
+        {host: 'proxy', container: 3000},
+        {host: 'proxy', container: 4000}
+      ])
+
+      expect(ports()).toEqual([{host: 'proxy', container: 3000}])
+    })
+
+    // Hub delivers commands as JSON over WebSocket, so every value arrives as a
+    // string. app.port.set forwards payload.ports to setPorts verbatim.
+    test('should accept a Hub-shaped payload where every value is a string', async () => {
+      const payload = JSON.parse('{"name":"web","ports":[{"host":"proxy","container":"3000"},{"host":"8080","container":"8080"}]}')
+
+      const result = await App.setPorts(payload.name, payload.ports)
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([
+        {host: 'proxy', container: 3000},
+        {host: 8080, container: 8080}
+      ])
+    })
+
+    test('should reject a Hub payload with a missing ports key rather than throwing', async () => {
+      const payload = JSON.parse('{"name":"web"}')
+
+      const result = await App.setPorts(payload.name, payload.ports)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Expected an array/)
+    })
+  })
+
+  describe('legacy port migration', () => {
+    test('should stamp the proxy sentinel onto host-less entries on load', async () => {
+      mockConfig.apps = [{id: 1, name: 'web', type: 'container', ports: [{container: 3000}]}]
+
+      await App.init()
+
+      const {data: apps} = await App.list(true)
+      expect(apps[0].ports[0]).toEqual({host: 'proxy', container: 3000})
+    })
+
+    test('should leave published entries alone on load', async () => {
+      mockConfig.apps = [{id: 1, name: 'web', type: 'container', ports: [{host: 8080, container: 3000}]}]
+
+      await App.init()
+
+      const {data: apps} = await App.list(true)
+      expect(apps[0].ports[0]).toEqual({host: 8080, container: 3000})
+    })
+
+    test('should tolerate apps with no ports at all', async () => {
+      mockConfig.apps = [{id: 1, name: 'web', type: 'script'}]
+
+      await expect(App.init()).resolves.not.toThrow()
+    })
+  })
+
+  describe('runtime port auto-discovery', () => {
+    // #pollForPort waits 5 attempts (1s apart) before rewriting the config.
+    const POLL_SETTLE_MS = 7000
+
+    const runApp = async (app, listeningPorts) => {
+      mockConfig.apps = [app]
+      mockGetListeningPorts.mockResolvedValue(listeningPorts)
+
+      // #pollForPort re-arms itself with setTimeout; fake them so the 5-attempt
+      // grace period is instant. setImmediate stays real — check() awaits one.
+      jest.useFakeTimers({doNotFake: ['setImmediate', 'nextTick']})
+      try {
+        await App.check()
+        await jest.advanceTimersByTimeAsync(POLL_SETTLE_MS)
+      } finally {
+        jest.useRealTimers()
+      }
+
+      return mockConfig.apps[0].ports
+    }
+
+    test('should adopt the observed port for a proxy-routed app', async () => {
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 3000}]},
+        [5678]
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 5678}])
+    })
+
+    test('should not clobber a published host binding when the app listens elsewhere', async () => {
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 8080, container: 3000}]},
+        [5678]
+      )
+
+      expect(ports).toEqual([{host: 8080, container: 3000}])
+    })
+
+    test('should preserve secondary mappings when correcting the primary entry', async () => {
+      const ports = await runApp(
+        {
+          id: 1,
+          name: 'web',
+          type: 'container',
+          image: 'n8n',
+          active: true,
+          ports: [
+            {host: 'proxy', container: 3000},
+            {host: 9000, container: 9000}
+          ]
+        },
+        [5678]
+      )
+
+      expect(ports).toEqual([
+        {host: 'proxy', container: 5678},
+        {host: 9000, container: 9000}
+      ])
+    })
+
+    test('should leave the config alone when the app listens where expected', async () => {
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 3000}]},
+        [3000]
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 3000}])
+    })
+
+    test('should honour a user-chosen proxy port the app actually listens on', async () => {
+      // User moved the proxy port 3000 -> 5000 and restarted; the app binds both.
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 5000}]},
+        [3000, 5000]
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 5000}])
+    })
+
+    test('should overwrite a user-chosen proxy port the app never binds', async () => {
+      // Documents current behaviour: an unroutable choice is auto-healed, silently.
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 5000}]},
+        [3000]
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 3000}])
+    })
+
+    test('should hand Docker only the published ports', async () => {
+      await runApp(
+        {
+          id: 1,
+          name: 'web',
+          type: 'container',
+          image: 'nginx',
+          active: true,
+          ports: [
+            {host: 'proxy', container: 3000},
+            {host: 9000, container: 9000}
+          ]
+        },
+        [3000]
+      )
+
+      const runOptions = mockRunApp.mock.calls[0][1]
+      expect(runOptions.ports).toEqual([{host: 9000, container: 9000}])
     })
   })
 })

--- a/test/server/App.test.js
+++ b/test/server/App.test.js
@@ -481,7 +481,7 @@ describe('App', () => {
       // Manual envs
       expect(result.data.manual.NODE_ENV).toBe('production')
       expect(result.data.manual.API_KEY).toBe('***')
-      expect(result.data.manual.DB_PASS).toBe('***')
+      expect(result.data.manual.DB_PASS).toBe('password123') // pass is not masked
 
       // Linked section (empty initially)
       expect(result.data.linked).toEqual([])
@@ -535,7 +535,7 @@ describe('App', () => {
       expect(resolvedRes.data.linked).toHaveLength(1)
       expect(resolvedRes.data.linked[0].app).toBe('app-db')
       expect(resolvedRes.data.linked[0].env.POSTGRES_USER).toBe('admin')
-      expect(resolvedRes.data.linked[0].env.POSTGRES_PASSWORD).toBe('***')
+      expect(resolvedRes.data.linked[0].env.POSTGRES_PASSWORD).toBe('db-secret-password')
     })
 
     test('unlinkEnv should remove link', async () => {

--- a/test/server/App.test.js
+++ b/test/server/App.test.js
@@ -1267,14 +1267,32 @@ describe('App', () => {
       expect(result.message).toMatch(/Only one port may be routed by the proxy/)
     })
 
-    test('should reject duplicate container ports', async () => {
+    test('should accept one container port published on two host ports', async () => {
       const result = await App.setPorts('web', [
         {host: 8080, container: 3000},
         {host: 9090, container: 3000}
       ])
 
-      expect(result.success).toBe(false)
-      expect(result.message).toMatch(/Duplicate container port/)
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([
+        {host: 8080, container: 3000},
+        {host: 9090, container: 3000}
+      ])
+    })
+
+    test('should accept the same container port routed by the proxy and published', async () => {
+      // The proxy reaches the container over the docker network; publishing DNATs
+      // a host port to the same listener. The two paths never collide.
+      const result = await App.setPorts('web', [
+        {host: 'proxy', container: 3000},
+        {host: 8080, container: 3000}
+      ])
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([
+        {host: 'proxy', container: 3000},
+        {host: 8080, container: 3000}
+      ])
     })
 
     test('should reject duplicate host ports', async () => {
@@ -1328,6 +1346,75 @@ describe('App', () => {
       expect(result.success).toBe(false)
       expect(result.message).toMatch(/Expected an array/)
     })
+
+    test('should persist the public flag on a published port', async () => {
+      const result = await App.setPorts('web', [{host: 3307, container: 3306, public: true}])
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([{host: 3307, container: 3306, public: true}])
+    })
+
+    test('should omit the public flag when the port stays on loopback', async () => {
+      // An absent flag already means loopback; writing `public: false` into every
+      // stored config would churn them for nothing.
+      const result = await App.setPorts('web', [
+        {host: 3307, container: 3306, public: false},
+        {host: 8080, container: 8080}
+      ])
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([
+        {host: 3307, container: 3306},
+        {host: 8080, container: 8080}
+      ])
+    })
+
+    test('should mark an auto-assigned host port public', async () => {
+      const result = await App.setPorts('web', [{host: 'auto', container: 3306, public: true}])
+
+      expect(result.success).toBe(true)
+      expect(ports()[0].public).toBe(true)
+      expect(typeof ports()[0].host).toBe('number')
+    })
+
+    test('should reject a public proxy port', async () => {
+      const result = await App.setPorts('web', [{host: 'proxy', container: 3000, public: true}])
+
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/cannot be public/)
+    })
+
+    test('should reject a public flag that is not a boolean', async () => {
+      const result = await App.setPorts('web', [{host: 3307, container: 3306, public: 'yes'}])
+
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/Invalid public flag/)
+    })
+
+    test('should not leave the app mutated when the public flag is rejected', async () => {
+      await App.setPorts('web', [{host: 3307, container: 3306, public: 1}])
+
+      expect(ports()).toEqual([{host: 'proxy', container: 3000}])
+    })
+
+    // The dashboard checkbox may serialize as a string on its way through Hub.
+    test('should accept a Hub-shaped public flag sent as a string', async () => {
+      const payload = JSON.parse('{"name":"web","ports":[{"host":"3307","container":"3306","public":"true"}]}')
+
+      const result = await App.setPorts(payload.name, payload.ports)
+
+      expect(result.success).toBe(true)
+      expect(ports()).toEqual([{host: 3307, container: 3306, public: true}])
+    })
+
+    test('should not read a stringified false as public', async () => {
+      const payload = JSON.parse('{"name":"web","ports":[{"host":"3307","container":"3306","public":"false"}]}')
+
+      const result = await App.setPorts(payload.name, payload.ports)
+
+      expect(result.success).toBe(true)
+      expect(ports()[0].public).toBeUndefined()
+    })
   })
 
   describe('legacy port migration', () => {
@@ -1337,7 +1424,26 @@ describe('App', () => {
       await App.init()
 
       const {data: apps} = await App.list(true)
-      expect(apps[0].ports[0]).toEqual({host: 'proxy', container: 3000})
+      expect(apps[0].ports[0]).toEqual({host: 'proxy', container: 3000, auto: true})
+    })
+
+    test('should let auto-discovery correct a migrated legacy entry', async () => {
+      // Before the marker existed these were correctable; migration must not
+      // quietly freeze them on a port the app never binds.
+      mockConfig.apps = [{id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{container: 3000}]}]
+
+      await App.init()
+      mockGetListeningPorts.mockResolvedValue([5678])
+
+      jest.useFakeTimers({doNotFake: ['setImmediate', 'nextTick']})
+      try {
+        await App.check()
+        await jest.advanceTimersByTimeAsync(7000)
+      } finally {
+        jest.useRealTimers()
+      }
+
+      expect(mockConfig.apps[0].ports[0]).toEqual({host: 'proxy', container: 5678, auto: true})
     })
 
     test('should leave published entries alone on load', async () => {
@@ -1377,13 +1483,24 @@ describe('App', () => {
       return mockConfig.apps[0].ports
     }
 
-    test('should adopt the observed port for a proxy-routed app', async () => {
+    test('should adopt the observed port for a guessed proxy entry', async () => {
       const ports = await runApp(
-        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 3000}]},
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 3000, auto: true}]},
         [5678]
       )
 
-      expect(ports).toEqual([{host: 'proxy', container: 5678}])
+      expect(ports).toEqual([{host: 'proxy', container: 5678, auto: true}])
+    })
+
+    test('should keep correcting a guess it already corrected once', async () => {
+      // The entry stays a guess after a correction, or a wrong first guess would
+      // freeze the app on a port it never binds.
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 5678, auto: true}]},
+        [8080]
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 8080, auto: true}])
     })
 
     test('should not clobber a published host binding when the app listens elsewhere', async () => {
@@ -1404,7 +1521,7 @@ describe('App', () => {
           image: 'n8n',
           active: true,
           ports: [
-            {host: 'proxy', container: 3000},
+            {host: 'proxy', container: 3000, auto: true},
             {host: 9000, container: 9000}
           ]
         },
@@ -1412,8 +1529,30 @@ describe('App', () => {
       )
 
       expect(ports).toEqual([
-        {host: 'proxy', container: 5678},
+        {host: 'proxy', container: 5678, auto: true},
         {host: 9000, container: 9000}
+      ])
+    })
+
+    test('should correct the proxy entry wherever it sits in the list', async () => {
+      const ports = await runApp(
+        {
+          id: 1,
+          name: 'web',
+          type: 'container',
+          image: 'n8n',
+          active: true,
+          ports: [
+            {host: 9000, container: 9000},
+            {host: 'proxy', container: 3000, auto: true}
+          ]
+        },
+        [5678]
+      )
+
+      expect(ports).toEqual([
+        {host: 9000, container: 9000},
+        {host: 'proxy', container: 5678, auto: true}
       ])
     })
 
@@ -1436,11 +1575,22 @@ describe('App', () => {
       expect(ports).toEqual([{host: 'proxy', container: 5000}])
     })
 
-    test('should overwrite a user-chosen proxy port the app never binds', async () => {
-      // Documents current behaviour: an unroutable choice is auto-healed, silently.
+    test('should not overwrite a user-chosen proxy port the app never binds', async () => {
+      // The choice is unroutable, but it is the user's. Silently healing it would
+      // undo the port they just saved from the dashboard on the next restart.
       const ports = await runApp(
         {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 5000}]},
         [3000]
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 5000}])
+    })
+
+    test('should not adopt a port for an entry a recipe declared', async () => {
+      // Recipe ports go through #preparePorts, which never stamps `auto`.
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'n8n', active: true, ports: [{host: 'proxy', container: 3000}]},
+        [5678]
       )
 
       expect(ports).toEqual([{host: 'proxy', container: 3000}])
@@ -1464,6 +1614,23 @@ describe('App', () => {
 
       const runOptions = mockRunApp.mock.calls[0][1]
       expect(runOptions.ports).toEqual([{host: 9000, container: 9000}])
+    })
+
+    test('should carry the public flag through to Docker', async () => {
+      await runApp(
+        {
+          id: 1,
+          name: 'db',
+          type: 'container',
+          image: 'mysql',
+          active: true,
+          ports: [{host: 3307, container: 3306, public: true}]
+        },
+        [3306]
+      )
+
+      const runOptions = mockRunApp.mock.calls[0][1]
+      expect(runOptions.ports).toEqual([{host: 3307, container: 3306, public: true}])
     })
   })
 })

--- a/test/server/App.test.js
+++ b/test/server/App.test.js
@@ -19,6 +19,37 @@ jest.mock('fs', () => ({
   }))
 }))
 
+// Auto-discovery probes container ports over HTTP. `httpPorts` names the ports
+// that answer; every other port refuses the connection, the way a database does.
+jest.mock('http', () => {
+  const {EventEmitter} = require('events')
+
+  const mock = {
+    httpPorts: new Set(),
+    request(options, onResponse) {
+      const req = new EventEmitter()
+      req.destroy = jest.fn()
+      req.end = () => {
+        // nextTick, not setImmediate: the discovery tests run on fake timers, which
+        // flush microtasks between ticks but never turn the event loop's check phase.
+        process.nextTick(() => {
+          if (mock.httpPorts.has(options.port)) {
+            onResponse({destroy: jest.fn()})
+          } else {
+            req.emit('error', new Error('ECONNREFUSED'))
+          }
+        })
+      }
+
+      return req
+    }
+  }
+
+  return mock
+})
+
+const http = require('http')
+
 let App
 
 describe('App', () => {
@@ -26,6 +57,8 @@ describe('App', () => {
   let mockRunApp
   let mockCloneRepo
   let mockGetListeningPorts
+  let mockGetIP
+  let mockGetImageExposedPorts
 
   beforeEach(() => {
     // Reset config for each test
@@ -33,6 +66,9 @@ describe('App', () => {
     mockRunApp = jest.fn()
     mockCloneRepo = jest.fn()
     mockGetListeningPorts = jest.fn(() => [3000]) // Default: pass the readiness probe
+    mockGetIP = jest.fn(() => '10.0.0.5') // Mock IP to prevent infinite loop
+    mockGetImageExposedPorts = jest.fn(() => [])
+    http.httpPorts = new Set()
 
     // Mock global translation
     global.__ = msg => msg
@@ -70,11 +106,11 @@ describe('App', () => {
             list: jest.fn(() => []),
             getStats: jest.fn(),
             getStatus: jest.fn(() => Promise.resolve({running: false, restarts: 0})),
-            getIP: jest.fn(() => '10.0.0.5'), // Mock IP to prevent infinite loop
+            getIP: mockGetIP,
             getListeningPorts: mockGetListeningPorts,
             remove: jest.fn(),
             fetchRepo: jest.fn(),
-            getImageExposedPorts: jest.fn(() => []),
+            getImageExposedPorts: mockGetImageExposedPorts,
             logs: jest.fn().mockResolvedValue({}),
             docker: {
               getContainer: jest.fn(() => ({
@@ -1434,6 +1470,7 @@ describe('App', () => {
 
       await App.init()
       mockGetListeningPorts.mockResolvedValue([5678])
+      http.httpPorts = new Set([5678])
 
       jest.useFakeTimers({doNotFake: ['setImmediate', 'nextTick']})
       try {
@@ -1466,9 +1503,11 @@ describe('App', () => {
     // #pollForPort waits 5 attempts (1s apart) before rewriting the config.
     const POLL_SETTLE_MS = 7000
 
-    const runApp = async (app, listeningPorts) => {
+    // A listening port answers the HTTP probe unless the test says otherwise.
+    const runApp = async (app, listeningPorts, httpPorts = listeningPorts) => {
       mockConfig.apps = [app]
       mockGetListeningPorts.mockResolvedValue(listeningPorts)
+      http.httpPorts = new Set(httpPorts)
 
       // #pollForPort re-arms itself with setTimeout; fake them so the 5-attempt
       // grace period is instant. setImmediate stays real — check() awaits one.
@@ -1594,6 +1633,93 @@ describe('App', () => {
       )
 
       expect(ports).toEqual([{host: 'proxy', container: 3000}])
+    })
+
+    test('should not adopt a lone port that does not speak HTTP', async () => {
+      // A database app binds 5432 and nothing else. Adopting it would hand the
+      // proxy a backend that can never serve a request, so the guess stands.
+      const ports = await runApp(
+        {id: 1, name: 'db', type: 'container', image: 'postgres', active: true, ports: [{host: 'proxy', container: 3000, auto: true}]},
+        [5432],
+        []
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 3000, auto: true}])
+    })
+
+    test('should adopt the HTTP port when the app also listens on a database port', async () => {
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'app', active: true, ports: [{host: 'proxy', container: 3000, auto: true}]},
+        [5432, 8000],
+        [8000]
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 8000, auto: true}])
+    })
+
+    test('should keep polling until a listening port starts answering HTTP', async () => {
+      // The app binds its socket before it serves, so the first probes fail.
+      mockConfig.apps = [
+        {id: 1, name: 'web', type: 'container', image: 'app', active: true, ports: [{host: 'proxy', container: 3000, auto: true}]}
+      ]
+      mockGetListeningPorts.mockResolvedValue([5678])
+      http.httpPorts = new Set()
+
+      jest.useFakeTimers({doNotFake: ['setImmediate', 'nextTick']})
+      try {
+        await App.check()
+        await jest.advanceTimersByTimeAsync(POLL_SETTLE_MS)
+
+        expect(mockConfig.apps[0].ports).toEqual([{host: 'proxy', container: 3000, auto: true}])
+
+        http.httpPorts = new Set([5678])
+        await jest.advanceTimersByTimeAsync(POLL_SETTLE_MS)
+      } finally {
+        jest.useRealTimers()
+      }
+
+      expect(mockConfig.apps[0].ports).toEqual([{host: 'proxy', container: 5678, auto: true}])
+    })
+
+    test('should fall back to a well-known port when the container IP is unknown', async () => {
+      // No IP means no probe. Guessing beats leaving the app unroutable.
+      mockGetIP.mockResolvedValue(null)
+
+      const ports = await runApp(
+        {id: 1, name: 'web', type: 'container', image: 'app', active: true, ports: [{host: 'proxy', container: 3000, auto: true}]},
+        [5432, 8080],
+        []
+      )
+
+      expect(ports).toEqual([{host: 'proxy', container: 8080, auto: true}])
+    })
+
+    test('should give a database app no port mapping at all', async () => {
+      // A recipe that ships no ports leaves the app with none. MariaDB EXPOSEs 3306
+      // and binds it, but nothing there speaks HTTP, so the proxy has no business
+      // claiming it — and a `proxy: 3306` row the proxy can never route is worse
+      // than no row.
+      mockGetImageExposedPorts.mockResolvedValue([3306])
+
+      const ports = await runApp({id: 1, name: 'db', type: 'container', image: 'mariadb', active: true}, [3306], [])
+
+      expect(ports).toBeUndefined()
+      expect(mockRunApp.mock.calls[0][1].env.PORT).toBe('3306')
+    })
+
+    test('should write the proxy mapping for a portless app once a port answers HTTP', async () => {
+      const ports = await runApp({id: 1, name: 'web', type: 'container', image: 'app', active: true}, [8080], [8080])
+
+      expect(ports).toEqual([{host: 'proxy', container: 8080, auto: true}])
+    })
+
+    test('should not write a mapping from the image EXPOSE alone', async () => {
+      // EXPOSE is metadata, not evidence: the mapping waits for the probe.
+      mockGetImageExposedPorts.mockResolvedValue([8080])
+
+      const ports = await runApp({id: 1, name: 'web', type: 'container', image: 'app', active: true}, [], [])
+
+      expect(ports).toBeUndefined()
     })
 
     test('should hand Docker only the published ports', async () => {

--- a/test/server/Container.test.js
+++ b/test/server/Container.test.js
@@ -1,0 +1,104 @@
+const Ports = require('../../server/src/Ports')
+
+// Mock Odac before requiring Container: its module scope calls Odac.core('Log').
+global.Odac = {
+  core: jest.fn(name => {
+    if (name === 'Log') return {init: () => ({log: jest.fn(), error: jest.fn()})}
+    if (name === 'Config') return {config: {container: {available: true}}}
+    return {}
+  }),
+  server: jest.fn(name => {
+    if (name === 'Ports') return Ports
+    return {}
+  })
+}
+
+jest.mock('dockerode')
+
+const Docker = require('dockerode')
+
+// Container is a singleton that news up Docker at require time, so the mock has
+// to be in place before the module is loaded.
+const mockDocker = {
+  ping: jest.fn().mockResolvedValue(true),
+  listNetworks: jest.fn().mockResolvedValue([{Name: 'odac-network'}]),
+  createNetwork: jest.fn().mockResolvedValue({}),
+  getImage: jest.fn().mockReturnValue({inspect: jest.fn().mockResolvedValue({Id: 'sha256:abc'})}),
+  getContainer: jest.fn().mockReturnValue({
+    stop: jest.fn().mockRejectedValue({statusCode: 404}),
+    remove: jest.fn().mockRejectedValue({statusCode: 404}),
+    inspect: jest.fn().mockRejectedValue({statusCode: 404})
+  }),
+  createContainer: jest.fn().mockResolvedValue({start: jest.fn().mockResolvedValue(true)})
+}
+
+Docker.mockImplementation(() => mockDocker)
+
+const Container = require('../../server/src/Container')
+
+describe('Container.runApp() port publishing', () => {
+  beforeEach(() => {
+    mockDocker.createContainer.mockClear()
+  })
+
+  /** Runs the app and returns the config handed to Docker. */
+  const createOptionsFor = async ports => {
+    await Container.runApp('web', {image: 'nginx', ports})
+
+    return mockDocker.createContainer.mock.calls[0][0]
+  }
+
+  test('binds a published port to loopback', async () => {
+    const config = await createOptionsFor([{host: 8080, container: 3000}])
+
+    expect(config.HostConfig.PortBindings).toEqual({'3000/tcp': [{HostPort: '8080', HostIp: '127.0.0.1'}]})
+    expect(config.ExposedPorts).toEqual({'3000/tcp': {}})
+  })
+
+  test('binds a public port to every interface', async () => {
+    const config = await createOptionsFor([{host: 8080, container: 3000, public: true}])
+
+    expect(config.HostConfig.PortBindings).toEqual({'3000/tcp': [{HostPort: '8080', HostIp: ''}]})
+  })
+
+  test('never publishes a proxy-routed entry', async () => {
+    const config = await createOptionsFor([
+      {host: 'proxy', container: 3000},
+      {host: 9000, container: 9000}
+    ])
+
+    expect(config.HostConfig.PortBindings).toEqual({'9000/tcp': [{HostPort: '9000', HostIp: '127.0.0.1'}]})
+    expect(config.ExposedPorts).toEqual({'9000/tcp': {}})
+  })
+
+  test('keeps both host bindings when one container port is published twice', async () => {
+    // Assigning instead of appending here would silently drop the 8080 binding.
+    const config = await createOptionsFor([
+      {host: 8080, container: 3000},
+      {host: 9090, container: 3000}
+    ])
+
+    expect(config.HostConfig.PortBindings).toEqual({
+      '3000/tcp': [
+        {HostPort: '8080', HostIp: '127.0.0.1'},
+        {HostPort: '9090', HostIp: '127.0.0.1'}
+      ]
+    })
+  })
+
+  test('lets one container port be both proxy-routed and published', async () => {
+    const config = await createOptionsFor([
+      {host: 'proxy', container: 3000},
+      {host: 8080, container: 3000, public: true}
+    ])
+
+    expect(config.HostConfig.PortBindings).toEqual({'3000/tcp': [{HostPort: '8080', HostIp: ''}]})
+  })
+
+  test('publishes nothing when every entry is proxy-routed', async () => {
+    const config = await createOptionsFor([{host: 'proxy', container: 3000}])
+
+    expect(config.HostConfig.PortBindings).toEqual({})
+    expect(config.ExposedPorts).toEqual({})
+  })
+})

--- a/test/server/Container.test.js
+++ b/test/server/Container.test.js
@@ -1,5 +1,7 @@
 const Ports = require('../../server/src/Ports')
 
+const mockApp = {list: jest.fn()}
+
 // Mock Odac before requiring Container: its module scope calls Odac.core('Log').
 global.Odac = {
   core: jest.fn(name => {
@@ -9,6 +11,7 @@ global.Odac = {
   }),
   server: jest.fn(name => {
     if (name === 'Ports') return Ports
+    if (name === 'App') return mockApp
     return {}
   })
 }
@@ -100,5 +103,102 @@ describe('Container.runApp() port publishing', () => {
 
     expect(config.HostConfig.PortBindings).toEqual({})
     expect(config.ExposedPorts).toEqual({})
+  })
+})
+
+describe('Container.createTerminalSession()', () => {
+  const {PassThrough} = require('stream')
+
+  let containerMock
+
+  const appList = names => ({result: true, data: names.map(name => ({name}))})
+
+  beforeEach(() => {
+    containerMock = {
+      inspect: jest.fn().mockResolvedValue({State: {Running: true}}),
+      exec: jest.fn(async options => {
+        if (!options.Tty) {
+          const stream = new PassThrough()
+          stream.end()
+          return {start: async () => stream}
+        }
+        return {
+          start: jest.fn().mockResolvedValue(new PassThrough()),
+          inspect: jest.fn().mockResolvedValue({Running: false, ExitCode: 0}),
+          resize: jest.fn()
+        }
+      })
+    }
+    mockDocker.getContainer.mockReturnValue(containerMock)
+    mockApp.list.mockResolvedValue(appList(['web', 'api']))
+  })
+
+  afterAll(() => {
+    mockDocker.getContainer.mockReturnValue({
+      stop: jest.fn().mockRejectedValue({statusCode: 404}),
+      remove: jest.fn().mockRejectedValue({statusCode: 404}),
+      inspect: jest.fn().mockRejectedValue({statusCode: 404})
+    })
+  })
+
+  test('opens a TTY session for a managed, running app', async () => {
+    // Timers off: the default idle/lifetime timers would outlive the test run.
+    const terminal = await Container.createTerminalSession('web', {cols: 100, rows: 30, idleTimeout: 0, maxLifetime: 0})
+
+    expect(terminal.container).toBe('web')
+    expect(containerMock.exec).toHaveBeenCalledWith(expect.objectContaining({Tty: true, ConsoleSize: [30, 100]}))
+  })
+
+  test('refuses a container that is not a managed app', async () => {
+    // The odac container itself mounts the Docker socket: a shell in it is host root.
+    await expect(Container.createTerminalSession('odac')).rejects.toThrow('Unknown app: odac')
+    expect(containerMock.exec).not.toHaveBeenCalled()
+  })
+
+  test('refuses an app that is not running', async () => {
+    containerMock.inspect.mockResolvedValue({State: {Running: false}})
+
+    await expect(Container.createTerminalSession('web')).rejects.toThrow('is not running')
+    expect(containerMock.exec).not.toHaveBeenCalled()
+  })
+
+  test('refuses when the app list cannot be read', async () => {
+    mockApp.list.mockResolvedValue({result: false})
+
+    await expect(Container.createTerminalSession('web')).rejects.toThrow('Unknown app: web')
+    expect(containerMock.exec).not.toHaveBeenCalled()
+  })
+
+  test('refuses a shell in a privileged container', async () => {
+    // A --privileged container has host devices and kernel caps: a shell in it is host root.
+    containerMock.inspect.mockResolvedValue({State: {Running: true}, HostConfig: {Privileged: true}})
+
+    await expect(Container.createTerminalSession('web')).rejects.toThrow('privileged')
+    expect(containerMock.exec).not.toHaveBeenCalled()
+  })
+
+  test('allows a privileged container only when explicitly opted in', async () => {
+    containerMock.inspect.mockResolvedValue({State: {Running: true}, HostConfig: {Privileged: true}})
+
+    const terminal = await Container.createTerminalSession('web', {allowPrivileged: true, idleTimeout: 0, maxLifetime: 0})
+
+    expect(terminal.container).toBe('web')
+    expect(containerMock.exec).toHaveBeenCalledWith(expect.objectContaining({Tty: true}))
+  })
+
+  test('defaults the exec to the app user rather than root', async () => {
+    containerMock.inspect.mockResolvedValue({State: {Running: true}, Config: {User: 'app'}})
+
+    await Container.createTerminalSession('web', {idleTimeout: 0, maxLifetime: 0})
+
+    expect(containerMock.exec).toHaveBeenCalledWith(expect.objectContaining({User: 'app'}))
+  })
+
+  test('an explicit user overrides the container user', async () => {
+    containerMock.inspect.mockResolvedValue({State: {Running: true}, Config: {User: 'app'}})
+
+    await Container.createTerminalSession('web', {user: 'root', idleTimeout: 0, maxLifetime: 0})
+
+    expect(containerMock.exec).toHaveBeenCalledWith(expect.objectContaining({User: 'root'}))
   })
 })

--- a/test/server/HubTerminal.test.js
+++ b/test/server/HubTerminal.test.js
@@ -1,0 +1,358 @@
+const {MockOdac} = require('./__mocks__/globalOdac')
+
+const mockOdac = new MockOdac()
+mockOdac.setMock('core', 'Log', {init: jest.fn().mockReturnValue({log: jest.fn(), error: jest.fn()})})
+global.Odac = mockOdac
+
+jest.mock('ws', () => {
+  const {EventEmitter} = require('events')
+
+  class FakeWebSocket extends EventEmitter {
+    static OPEN = 1
+    static instances = []
+
+    constructor(url, options) {
+      super()
+      this.url = url
+      this.options = options
+      this.readyState = 0
+      this.bufferedAmount = 0
+      this.sent = []
+      this.terminated = false
+      FakeWebSocket.instances.push(this)
+    }
+
+    send(data, options) {
+      this.sent.push({data, binary: Boolean(options?.binary)})
+    }
+
+    close() {
+      this.readyState = 3
+      this.emit('close')
+    }
+
+    terminate() {
+      this.terminated = true
+      this.readyState = 3
+    }
+  }
+
+  return FakeWebSocket
+})
+
+const FakeWebSocket = require('ws')
+const TerminalManager = require('../../server/src/Hub/Terminal')
+
+const flush = () => new Promise(resolve => setImmediate(resolve))
+const lastSocket = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+
+/** The Terminal returned by Container.createTerminalSession(). */
+function createTerminalStub() {
+  const stub = {
+    closed: false,
+    write: jest.fn(),
+    resize: jest.fn(),
+    close: jest.fn(async reason => {
+      stub.closed = true
+      stub.closeReason = reason
+    })
+  }
+  return stub
+}
+
+let terminalStub
+let createTerminalSession
+
+function configure(terminal = {enabled: true}) {
+  mockOdac.setMock('core', 'Config', {config: {hub: {token: 'tok', terminal}}})
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = []
+  terminalStub = createTerminalStub()
+
+  createTerminalSession = jest.fn(async (app, options) => {
+    terminalStub.app = app
+    terminalStub.options = options
+    return terminalStub
+  })
+
+  mockOdac.setMock('server', 'Container', {createTerminalSession})
+  configure()
+})
+
+const manager = () => new TerminalManager({wsUrl: 'wss://hub.odac.run/ws', getToken: () => 'tok'})
+
+const payload = (overrides = {}) => ({app: 'web', sessionId: 'sess-abcdef12', ticket: 'ticket-abcdef12', cols: 100, rows: 30, ...overrides})
+
+/** Drives open() to completion by letting the fake socket connect. */
+async function open(mgr, options = payload()) {
+  const pending = mgr.open(options)
+  await flush()
+  await flush()
+
+  const socket = lastSocket()
+  if (socket) {
+    socket.readyState = FakeWebSocket.OPEN
+    socket.emit('open')
+  }
+
+  return pending
+}
+
+describe('TerminalManager.open() guards', () => {
+  test('is enabled by default (empty config still opens)', async () => {
+    configure({})
+    const result = await open(manager())
+
+    expect(result.success).toBe(true)
+    expect(createTerminalSession).toHaveBeenCalled()
+  })
+
+  test('an operator can switch it off with enabled:false', async () => {
+    configure({enabled: false})
+    const result = await manager().open(payload())
+
+    expect(result).toEqual({success: false, message: 'Terminal access is disabled'})
+    expect(createTerminalSession).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    ['session id', {sessionId: 'short'}],
+    ['session id with a path traversal', {sessionId: '../../etc'}],
+    ['ticket', {ticket: 'nope'}]
+  ])('rejects a malformed %s before dialing', async (_label, override) => {
+    const result = await manager().open(payload(override))
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Invalid session id or ticket')
+    expect(FakeWebSocket.instances).toHaveLength(0)
+    expect(createTerminalSession).not.toHaveBeenCalled()
+  })
+
+  test('enforces the concurrent session cap', async () => {
+    configure({enabled: true, maxSessions: 1})
+    const mgr = manager()
+
+    await open(mgr)
+    const second = await mgr.open(payload({sessionId: 'sess-99999999'}))
+
+    expect(second).toEqual({success: false, message: 'Too many terminal sessions (max 1)'})
+    expect(mgr.count).toBe(1)
+  })
+
+  test('refuses a duplicate session id', async () => {
+    const mgr = manager()
+    await open(mgr)
+
+    const again = await mgr.open(payload())
+    expect(again).toEqual({success: false, message: 'Session already open'})
+  })
+
+  test('refuses when the agent has no Hub token', async () => {
+    const mgr = new TerminalManager({wsUrl: 'wss://hub.odac.run/ws', getToken: () => undefined})
+    const result = await mgr.open(payload())
+
+    expect(result).toEqual({success: false, message: 'Not authenticated'})
+  })
+
+  test('surfaces a rejected app and frees the slot', async () => {
+    createTerminalSession.mockRejectedValue(new Error('Unknown app: odac'))
+    const mgr = manager()
+
+    const result = await mgr.open(payload({app: 'odac'}))
+
+    expect(result).toEqual({success: false, message: 'Unknown app: odac'})
+    expect(mgr.count).toBe(0)
+    // The exec is validated before the Hub is dialed, so no socket was ever opened.
+    expect(FakeWebSocket.instances).toHaveLength(0)
+  })
+
+  test('reaps the exec when the socket fails to connect', async () => {
+    const mgr = manager()
+    const pending = mgr.open(payload())
+    await flush()
+    await flush()
+
+    lastSocket().emit('error', new Error('handshake failed'))
+    const result = await pending
+
+    expect(result.success).toBe(false)
+    expect(terminalStub.close).toHaveBeenCalledWith('error')
+    expect(mgr.count).toBe(0)
+  })
+})
+
+describe('TerminalManager.open() success', () => {
+  test('dials the per-session endpoint with token and ticket', async () => {
+    const mgr = manager()
+    const result = await open(mgr)
+
+    expect(result).toEqual({success: true, message: 'Terminal session opened', data: {sessionId: 'sess-abcdef12', app: 'web'}})
+    expect(mgr.count).toBe(1)
+
+    const socket = lastSocket()
+    expect(socket.url).toBe('wss://hub.odac.run/ws/terminal/sess-abcdef12')
+    expect(socket.options.headers).toEqual({Authorization: 'Bearer tok', 'X-Odac-Ticket': 'ticket-abcdef12'})
+    expect(socket.options.rejectUnauthorized).toBe(true)
+  })
+
+  test('passes the requested size and the configured limits to the exec', async () => {
+    configure({enabled: true, idleTimeout: 1000, maxLifetime: 2000})
+    await open(manager())
+
+    expect(createTerminalSession).toHaveBeenCalledWith(
+      'web',
+      expect.objectContaining({cols: 100, rows: 30, idleTimeout: 1000, maxLifetime: 2000})
+    )
+  })
+
+  test('does not permit privileged containers unless configured', async () => {
+    await open(manager())
+    expect(createTerminalSession).toHaveBeenCalledWith('web', expect.objectContaining({allowPrivileged: false}))
+  })
+
+  test('threads the privileged opt-in through to the exec', async () => {
+    configure({enabled: true, allowPrivileged: true})
+    await open(manager())
+    expect(createTerminalSession).toHaveBeenCalledWith('web', expect.objectContaining({allowPrivileged: true}))
+  })
+})
+
+describe('TerminalSession framing', () => {
+  test('pty output goes out as binary frames', async () => {
+    await open(manager())
+
+    terminalStub.options.onData(Buffer.from('hello'))
+
+    expect(lastSocket().sent).toEqual([{data: Buffer.from('hello'), binary: true}])
+  })
+
+  test('binary frames are written straight to the pty', async () => {
+    await open(manager())
+
+    lastSocket().emit('message', Buffer.from('ls\n'), true)
+
+    expect(terminalStub.write).toHaveBeenCalledWith(Buffer.from('ls\n'))
+  })
+
+  test('a text resize frame resizes the pty', async () => {
+    await open(manager())
+
+    lastSocket().emit('message', Buffer.from(JSON.stringify({type: 'resize', cols: 120, rows: 40})), false)
+
+    expect(terminalStub.resize).toHaveBeenCalledWith(120, 40)
+  })
+
+  test('a text close frame ends the session', async () => {
+    const mgr = manager()
+    await open(mgr)
+
+    lastSocket().emit('message', Buffer.from(JSON.stringify({type: 'close'})), false)
+    await flush()
+
+    expect(terminalStub.close).toHaveBeenCalledWith('remote')
+    expect(mgr.count).toBe(0)
+  })
+
+  test('a malformed control frame is ignored, not fatal', async () => {
+    const mgr = manager()
+    await open(mgr)
+
+    lastSocket().emit('message', Buffer.from('{not json'), false)
+    await flush()
+
+    expect(mgr.count).toBe(1)
+    expect(terminalStub.write).not.toHaveBeenCalled()
+  })
+
+  test('a socket error after connect does not crash the session', async () => {
+    const mgr = manager()
+    await open(mgr)
+
+    // 'ws' emits error before close; an unhandled 'error' would take the process down.
+    expect(() => lastSocket().emit('error', new Error('reset by peer'))).not.toThrow()
+  })
+})
+
+describe('TerminalSession teardown', () => {
+  test('the shell exiting tells the Hub, then hangs up', async () => {
+    const mgr = manager()
+    await open(mgr)
+    const socket = lastSocket()
+
+    terminalStub.closed = true
+    terminalStub.options.onExit({reason: 'exited', exitCode: 7})
+    await flush()
+
+    expect(socket.sent).toEqual([{data: JSON.stringify({type: 'exit', reason: 'exited', exitCode: 7}), binary: false}])
+    expect(mgr.count).toBe(0)
+  })
+
+  test('the socket dropping reaps the exec', async () => {
+    const mgr = manager()
+    await open(mgr)
+
+    lastSocket().close()
+    await flush()
+
+    expect(terminalStub.close).toHaveBeenCalledWith('socket')
+    expect(mgr.count).toBe(0)
+  })
+
+  test('a session that outruns its socket is closed rather than buffered', async () => {
+    const mgr = manager()
+    await open(mgr)
+    const socket = lastSocket()
+
+    socket.bufferedAmount = 9 * 1024 * 1024
+    terminalStub.options.onData(Buffer.from('flood'))
+    await flush()
+
+    expect(socket.sent).toHaveLength(0)
+    expect(terminalStub.close).toHaveBeenCalledWith('overflow')
+    expect(mgr.count).toBe(0)
+  })
+
+  test('close() by command ends the session', async () => {
+    const mgr = manager()
+    await open(mgr)
+
+    await expect(mgr.close({sessionId: 'sess-abcdef12'})).resolves.toEqual({success: true, message: 'Terminal session closed'})
+    expect(terminalStub.close).toHaveBeenCalledWith('command')
+    expect(mgr.count).toBe(0)
+  })
+
+  test('close() on an unknown session is reported, not thrown', async () => {
+    await expect(manager().close({sessionId: 'sess-00000000'})).resolves.toEqual({success: false, message: 'Unknown session'})
+  })
+
+  test('closeAll() reaps every session when the Hub connection drops', async () => {
+    configure({enabled: true, maxSessions: 5})
+    const mgr = manager()
+
+    const first = terminalStub
+    await open(mgr)
+
+    terminalStub = createTerminalStub()
+    await open(mgr, payload({sessionId: 'sess-22222222'}))
+
+    expect(mgr.count).toBe(2)
+    await mgr.closeAll()
+
+    expect(first.close).toHaveBeenCalledWith('hub_disconnected')
+    expect(terminalStub.close).toHaveBeenCalledWith('hub_disconnected')
+    expect(mgr.count).toBe(0)
+  })
+
+  test('closing twice fires the exec teardown once', async () => {
+    const mgr = manager()
+    await open(mgr)
+
+    await mgr.close({sessionId: 'sess-abcdef12'})
+    lastSocket().emit('close')
+    await flush()
+
+    expect(terminalStub.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/server/Ports.test.js
+++ b/test/server/Ports.test.js
@@ -47,13 +47,154 @@ describe('Ports', () => {
     })
   })
 
+  describe('isPublic()', () => {
+    test('is true only when a published entry opts in', () => {
+      expect(Ports.isPublic({host: 8080, container: 3000, public: true})).toBe(true)
+      expect(Ports.isPublic({host: 8080, container: 3000, public: false})).toBe(false)
+      expect(Ports.isPublic({host: 8080, container: 3000})).toBe(false)
+    })
+
+    test('never reports a proxy-routed entry as public', () => {
+      expect(Ports.isPublic({host: 'proxy', container: 3000, public: true})).toBe(false)
+      expect(Ports.isPublic({container: 3000, public: true})).toBe(false)
+    })
+
+    test('does not accept a truthy non-boolean as opt-in', () => {
+      expect(Ports.isPublic({host: 8080, container: 3000, public: 'true'})).toBe(false)
+      expect(Ports.isPublic({host: 8080, container: 3000, public: 1})).toBe(false)
+    })
+
+    test('is safe on nullish entries', () => {
+      expect(Ports.isPublic(undefined)).toBe(false)
+      expect(Ports.isPublic(null)).toBe(false)
+    })
+  })
+
+  describe('bindIp()', () => {
+    test('binds loopback by default', () => {
+      expect(Ports.bindIp({host: 8080, container: 3000})).toBe('127.0.0.1')
+      expect(Ports.bindIp({host: 8080, container: 3000, public: false})).toBe('127.0.0.1')
+    })
+
+    test('binds every interface for a public entry', () => {
+      // Empty is Docker's own spelling of "0.0.0.0 and [::]"; naming the
+      // families would break hosts without IPv6.
+      expect(Ports.bindIp({host: 8080, container: 3000, public: true})).toBe('')
+    })
+
+    test('binds loopback for a proxy entry that wrongly claims to be public', () => {
+      expect(Ports.bindIp({host: 'proxy', container: 3000, public: true})).toBe('127.0.0.1')
+    })
+  })
+
+  describe('parsePublic()', () => {
+    test('passes booleans through', () => {
+      expect(Ports.parsePublic(true)).toBe(true)
+      expect(Ports.parsePublic(false)).toBe(false)
+    })
+
+    test('treats an absent flag as not public', () => {
+      expect(Ports.parsePublic(undefined)).toBe(false)
+      expect(Ports.parsePublic(null)).toBe(false)
+      expect(Ports.parsePublic('')).toBe(false)
+    })
+
+    test('accepts the stringified booleans a form or JSON payload may send', () => {
+      expect(Ports.parsePublic('true')).toBe(true)
+      expect(Ports.parsePublic('false')).toBe(false)
+    })
+
+    test('rejects values that are not booleans', () => {
+      expect(Ports.parsePublic('yes')).toBeNull()
+      expect(Ports.parsePublic(1)).toBeNull()
+      expect(Ports.parsePublic(0)).toBeNull()
+      expect(Ports.parsePublic({})).toBeNull()
+    })
+  })
+
+  describe('isAuto()', () => {
+    test('is true only for an entry ODAC guessed', () => {
+      expect(Ports.isAuto({host: 'proxy', container: 3000, auto: true})).toBe(true)
+      expect(Ports.isAuto({host: 'proxy', container: 3000})).toBe(false)
+      expect(Ports.isAuto({host: 'proxy', container: 3000, auto: false})).toBe(false)
+    })
+
+    test('does not accept a truthy non-boolean as a marker', () => {
+      expect(Ports.isAuto({host: 'proxy', container: 3000, auto: 'true'})).toBe(false)
+    })
+
+    test('is safe on nullish entries', () => {
+      expect(Ports.isAuto(undefined)).toBe(false)
+      expect(Ports.isAuto(null)).toBe(false)
+    })
+  })
+
+  describe('primary()', () => {
+    test('picks the proxy entry regardless of its position', () => {
+      const published = {host: 9000, container: 9000}
+      const proxy = {host: 'proxy', container: 3000}
+
+      expect(Ports.primary([proxy, published])).toBe(proxy)
+      expect(Ports.primary([published, proxy])).toBe(proxy)
+    })
+
+    test('picks a legacy entry with no host as the proxy entry', () => {
+      const legacy = {container: 3000}
+      expect(Ports.primary([{host: 9000, container: 9000}, legacy])).toBe(legacy)
+    })
+
+    test('falls back to the first entry when nothing is proxy-routed', () => {
+      const first = {host: 8080, container: 3000}
+      expect(Ports.primary([first, {host: 9090, container: 3000}])).toBe(first)
+    })
+
+    test('returns undefined when there are no entries', () => {
+      expect(Ports.primary([])).toBeUndefined()
+      expect(Ports.primary(undefined)).toBeUndefined()
+      expect(Ports.primary(null)).toBeUndefined()
+    })
+  })
+
+  describe('discovered()', () => {
+    test('builds a proxy-routed entry marked as a guess', () => {
+      expect(Ports.discovered(3000)).toEqual({host: 'proxy', container: 3000, auto: true})
+    })
+
+    test('builds an entry that isAuto and primary both recognize', () => {
+      const entry = Ports.discovered(8080)
+
+      expect(Ports.isAuto(entry)).toBe(true)
+      expect(Ports.isProxy(entry)).toBe(true)
+      expect(Ports.primary([{host: 9000, container: 9000}, entry])).toBe(entry)
+    })
+  })
+
   describe('normalize()', () => {
     test('stamps the sentinel onto legacy entries in place', () => {
       const ports = [{container: 3000}]
       const returned = Ports.normalize(ports)
 
       expect(returned).toBe(ports)
+      expect(ports[0]).toEqual({host: 'proxy', container: 3000, auto: true})
+    })
+
+    test('marks a legacy proxy entry as a guess', () => {
+      // No shipped surface could set a proxy container port by hand, so every
+      // legacy one was inferred and stays correctable by auto-discovery.
+      const ports = [{container: 3000}, {host: '', container: 4000}]
+      Ports.normalize(ports)
+
+      expect(Ports.isAuto(ports[0])).toBe(true)
+      expect(Ports.isAuto(ports[1])).toBe(true)
+    })
+
+    test('does not mark an explicit proxy entry as a guess', () => {
+      // Written by setPorts, so it is the user's choice and must survive restarts.
+      const ports = [{host: 'proxy', container: 3000}]
+      Ports.normalize(ports)
+
       expect(ports[0]).toEqual({host: 'proxy', container: 3000})
+      expect(Ports.isAuto(ports[0])).toBe(false)
     })
 
     test('leaves published entries untouched', () => {

--- a/test/server/Ports.test.js
+++ b/test/server/Ports.test.js
@@ -1,0 +1,84 @@
+const Ports = require('../../server/src/Ports')
+
+describe('Ports', () => {
+  describe('PROXY sentinel', () => {
+    test('exposes the sentinel host value', () => {
+      expect(Ports.PROXY).toBe('proxy')
+    })
+  })
+
+  describe('isProxy()', () => {
+    test('treats the explicit sentinel as proxy-routed', () => {
+      expect(Ports.isProxy({host: 'proxy', container: 3000})).toBe(true)
+    })
+
+    test('treats a legacy entry with no host as proxy-routed', () => {
+      expect(Ports.isProxy({container: 3000})).toBe(true)
+    })
+
+    test('treats an empty host as proxy-routed', () => {
+      expect(Ports.isProxy({host: '', container: 3000})).toBe(true)
+    })
+
+    test('rejects a published numeric host', () => {
+      expect(Ports.isProxy({host: 8080, container: 3000})).toBe(false)
+    })
+
+    test('rejects a published numeric host given as a string', () => {
+      expect(Ports.isProxy({host: '8080', container: 3000})).toBe(false)
+    })
+
+    test('is safe on nullish entries', () => {
+      expect(Ports.isProxy(undefined)).toBe(false)
+      expect(Ports.isProxy(null)).toBe(false)
+    })
+  })
+
+  describe('isPublished()', () => {
+    test('is true only for entries carrying a host binding', () => {
+      expect(Ports.isPublished({host: 8080, container: 3000})).toBe(true)
+      expect(Ports.isPublished({host: 'proxy', container: 3000})).toBe(false)
+      expect(Ports.isPublished({container: 3000})).toBe(false)
+    })
+
+    test('is safe on nullish entries', () => {
+      expect(Ports.isPublished(undefined)).toBe(false)
+      expect(Ports.isPublished(null)).toBe(false)
+    })
+  })
+
+  describe('normalize()', () => {
+    test('stamps the sentinel onto legacy entries in place', () => {
+      const ports = [{container: 3000}]
+      const returned = Ports.normalize(ports)
+
+      expect(returned).toBe(ports)
+      expect(ports[0]).toEqual({host: 'proxy', container: 3000})
+    })
+
+    test('leaves published entries untouched', () => {
+      const ports = [{host: 8080, container: 3000}]
+      Ports.normalize(ports)
+
+      expect(ports[0]).toEqual({host: 8080, container: 3000})
+    })
+
+    test('normalizes every entry, not just the first', () => {
+      const ports = [{host: 8080, container: 3000}, {container: 9000}]
+      Ports.normalize(ports)
+
+      expect(ports[1].host).toBe('proxy')
+    })
+
+    test('tolerates a missing or non-array ports field', () => {
+      expect(Ports.normalize(undefined)).toBeUndefined()
+      expect(() => Ports.normalize(null)).not.toThrow()
+    })
+
+    test('skips nullish entries', () => {
+      const ports = [null, {container: 3000}]
+      expect(() => Ports.normalize(ports)).not.toThrow()
+      expect(ports[1].host).toBe('proxy')
+    })
+  })
+})

--- a/test/server/Proxy.test.js
+++ b/test/server/Proxy.test.js
@@ -117,6 +117,49 @@ describe('Proxy', () => {
     })
   })
 
+  describe('backend resolution', () => {
+    /** Syncs one domain bound to `app` and returns the routing the proxy was handed. */
+    const routingFor = async ports => {
+      mockConfig.config.apps = [{id: 1, name: 'web', ports}]
+      mockConfig.config.domains = {'a.com': {appId: 'web'}}
+      mockOdac.setMock('server', 'Container', {available: true, getIP: jest.fn().mockResolvedValue('172.17.0.5')})
+
+      mockFs.readFileSync.mockImplementation(() => {
+        throw {code: 'ENOENT'}
+      })
+      ProxyService.spawnProxy()
+      await ProxyService.syncConfig()
+
+      const post = mockOdac.core('Http').post.mock.calls.find(c => c[0].includes('/config'))
+      return post[1].domains['a.com']
+    }
+
+    test('routes a proxy entry over the container network', async () => {
+      const routing = await routingFor([{host: 'proxy', container: 3000}])
+
+      expect(routing.port).toBe(3000)
+      expect(routing.containerIP).toBe('172.17.0.5')
+    })
+
+    test('routes a published-only app over the host network', async () => {
+      const routing = await routingFor([{host: 8080, container: 3000}])
+
+      expect(routing.port).toBe(8080)
+      expect(routing.containerIP).toBe('127.0.0.1')
+    })
+
+    test('prefers the proxy entry over a published one that precedes it', async () => {
+      // The sentinel declares who owns routing; list order must not decide it.
+      const routing = await routingFor([
+        {host: 8080, container: 3000},
+        {host: 'proxy', container: 3000}
+      ])
+
+      expect(routing.port).toBe(3000)
+      expect(routing.containerIP).toBe('172.17.0.5')
+    })
+  })
+
   describe('lifecycle', () => {
     test('should spawn proxy in check if active', async () => {
       ProxyService.start()

--- a/test/server/Terminal.test.js
+++ b/test/server/Terminal.test.js
@@ -1,0 +1,349 @@
+const {PassThrough} = require('stream')
+
+// Terminal's module scope calls Odac.core('Log'); jest.setup.js installs the global mock.
+const Terminal = require('../../server/src/Container/Terminal')
+
+/**
+ * Fake dockerode container.
+ *
+ * `exec()` serves two very different callers: the TTY session (Tty:true) and the throwaway
+ * reap execs (Tty absent). Reap scripts are captured so tests can assert on the signal sent.
+ */
+function createContainerMock({runningSequence = [false]} = {}) {
+  const sessionStream = new PassThrough()
+  sessionStream.destroy = jest.fn(sessionStream.destroy.bind(sessionStream))
+
+  const inspectResults = [...runningSequence]
+  const sessionExec = {
+    start: jest.fn(async opts => {
+      sessionExec.startOptions = opts
+      return sessionStream
+    }),
+    resize: jest.fn().mockResolvedValue(undefined),
+    inspect: jest.fn(async () => {
+      const running = inspectResults.length > 1 ? inspectResults.shift() : inspectResults[0]
+      return {Running: running, ExitCode: running ? null : 0}
+    })
+  }
+
+  const execOptions = []
+  const reapScripts = []
+
+  const container = {
+    exec: jest.fn(async options => {
+      execOptions.push(options)
+
+      if (options.Tty) return sessionExec
+
+      reapScripts.push(options.Cmd[2])
+      return {
+        start: async () => {
+          const stream = new PassThrough()
+          // End synchronously: Jest's fake timers also fake process.nextTick, so deferring
+          // this would stall the reap's `await stream.on('end')` in the timeout tests.
+          // 'end' still fires once #runInContainer attaches its drain listener.
+          stream.end()
+          return stream
+        }
+      }
+    })
+  }
+
+  const docker = {getContainer: jest.fn(() => container)}
+
+  return {docker, container, sessionExec, sessionStream, execOptions, reapScripts}
+}
+
+const sessionOptions = mock => mock.execOptions.find(o => o.Tty)
+
+/**
+ * Opens a session with the idle/lifetime timers off. Tests that leave a session open would
+ * otherwise strand a 15-minute timer and keep the Jest worker alive. The timeout suite below
+ * sets its own durations.
+ */
+const openTerminal = (mock, options = {}) => new Terminal(mock.docker, 'web', {idleTimeout: 0, maxLifetime: 0, ...options}).open()
+
+describe('Terminal.open()', () => {
+  test('creates a TTY exec sized up front and tagged with a session env var', async () => {
+    const mock = createContainerMock()
+    await openTerminal(mock, {cols: 120, rows: 40})
+
+    const options = sessionOptions(mock)
+    expect(options.Tty).toBe(true)
+    expect(options.AttachStdin).toBe(true)
+    // [h, w] — sizing at create avoids a first paint at 0x0.
+    expect(options.ConsoleSize).toEqual([40, 120])
+    expect(options.Env).toEqual([expect.stringMatching(/^ODAC_TTY_SESSION=[a-f0-9]{32}$/)])
+  })
+
+  test('repeats Tty on start, or the daemon streams multiplexed frames', async () => {
+    const mock = createContainerMock()
+    await openTerminal(mock)
+
+    expect(mock.sessionExec.startOptions).toEqual({hijack: true, stdin: true, Tty: true})
+  })
+
+  test('defaults to a bash-or-sh probe and honours an explicit command', async () => {
+    const mock = createContainerMock()
+    await openTerminal(mock)
+    expect(sessionOptions(mock).Cmd).toEqual(Terminal.DEFAULT_SHELL)
+
+    const custom = createContainerMock()
+    await openTerminal(custom, {command: ['/bin/zsh']})
+    expect(sessionOptions(custom).Cmd).toEqual(['/bin/zsh'])
+  })
+
+  test('passes user, workdir and extra env through', async () => {
+    const mock = createContainerMock()
+    await openTerminal(mock, {user: 'app', workdir: '/srv', env: ['FOO=bar']})
+
+    const options = sessionOptions(mock)
+    expect(options.User).toBe('app')
+    expect(options.WorkingDir).toBe('/srv')
+    expect(options.Env).toEqual([expect.stringMatching(/^ODAC_TTY_SESSION=/), 'FOO=bar'])
+  })
+
+  test('refuses to open twice', async () => {
+    const mock = createContainerMock()
+    const terminal = await openTerminal(mock)
+
+    await expect(terminal.open()).rejects.toThrow('already opened')
+  })
+})
+
+describe('Terminal I/O', () => {
+  test('forwards output to onData', async () => {
+    const mock = createContainerMock()
+    const chunks = []
+    await openTerminal(mock, {onData: c => chunks.push(c.toString())})
+
+    mock.sessionStream.write('hello')
+    await new Promise(r => setImmediate(r))
+
+    expect(chunks).toEqual(['hello'])
+  })
+
+  test('forwards input to the pty', async () => {
+    const mock = createContainerMock()
+    const terminal = await openTerminal(mock)
+
+    const written = []
+    mock.sessionStream.on('data', c => written.push(c.toString()))
+
+    expect(terminal.write('ls\n')).toBe(true)
+    await new Promise(r => setImmediate(r))
+
+    expect(written).toEqual(['ls\n'])
+  })
+
+  test('resize maps cols/rows onto Docker w/h', async () => {
+    const mock = createContainerMock()
+    const terminal = await openTerminal(mock)
+
+    await expect(terminal.resize(100, 30)).resolves.toBe(true)
+    expect(mock.sessionExec.resize).toHaveBeenCalledWith({h: 30, w: 100})
+  })
+
+  test('resize clamps nonsense dimensions instead of passing them to Docker', async () => {
+    const mock = createContainerMock()
+    const terminal = await openTerminal(mock, {cols: 80, rows: 24})
+
+    await terminal.resize(99999, 0)
+
+    // width capped, height fell back to the previous value rather than 0
+    expect(mock.sessionExec.resize).toHaveBeenCalledWith({h: 24, w: 1000})
+  })
+
+  test('resize survives a shell that exited mid-call', async () => {
+    const mock = createContainerMock()
+    const terminal = await openTerminal(mock)
+    mock.sessionExec.resize.mockRejectedValueOnce(new Error('no such exec'))
+
+    await expect(terminal.resize(90, 20)).resolves.toBe(false)
+  })
+
+  test('write and resize are no-ops once closed', async () => {
+    const mock = createContainerMock()
+    const terminal = await openTerminal(mock)
+    await terminal.close()
+
+    expect(terminal.write('x')).toBe(false)
+    await expect(terminal.resize(90, 20)).resolves.toBe(false)
+    expect(mock.sessionExec.resize).not.toHaveBeenCalled()
+  })
+})
+
+describe('Terminal.close() reaping', () => {
+  test('destroys the stream and hangs up the session tree', async () => {
+    const mock = createContainerMock({runningSequence: [false]})
+    const terminal = await openTerminal(mock)
+
+    await terminal.close()
+
+    expect(mock.sessionStream.destroy).toHaveBeenCalled()
+    expect(mock.reapScripts).toHaveLength(1)
+    expect(mock.reapScripts[0]).toContain('kill -HUP')
+    expect(terminal.closed).toBe(true)
+  })
+
+  test('escalates to SIGKILL when the shell ignores the hangup', async () => {
+    // Running: true after HUP, still true after the grace wait, false once KILLed.
+    const mock = createContainerMock({runningSequence: [true, true, false, false]})
+    const terminal = await openTerminal(mock)
+
+    await terminal.close()
+
+    expect(mock.reapScripts).toHaveLength(2)
+    expect(mock.reapScripts[0]).toContain('kill -HUP')
+    expect(mock.reapScripts[1]).toContain('kill -KILL')
+  }, 10000)
+
+  test('reaps as the session user, so a non-root shell can be read and signalled', async () => {
+    // The reap scans /proc/<pid>/environ; reading a process owned by a different uid needs
+    // CAP_SYS_PTRACE, which a stock container's exec lacks. Running the reaper as the shell's
+    // own user keeps both the environ read and the kill on the same-uid path.
+    const mock = createContainerMock({runningSequence: [false]})
+    const terminal = await openTerminal(mock, {user: 'app'})
+
+    await terminal.close()
+
+    const reapOptions = mock.execOptions.find(o => !o.Tty)
+    expect(reapOptions.User).toBe('app')
+  })
+
+  test('reap script targets only this session and cannot match itself', async () => {
+    const mock = createContainerMock()
+    await openTerminal(mock)
+
+    const tag = sessionOptions(mock).Env[0].split('=')[1]
+    await new Promise(r => setImmediate(r))
+    mock.sessionStream.end() // triggers close('exited')
+    await new Promise(r => setTimeout(r, 20))
+
+    const script = mock.reapScripts[0]
+    expect(script).toContain(`ODAC_TTY_SESSION=${tag}`)
+    // Single line: `done \n | sort` is a shell syntax error.
+    expect(script).not.toContain('\n')
+    // The reaping exec is untagged, so the sweep can never signal itself.
+    const reapExec = mock.execOptions.find(o => !o.Tty)
+    expect(reapExec.Env).toBeUndefined()
+  })
+
+  test('reap signals children before the shell, so no zombies are left behind', async () => {
+    const mock = createContainerMock({runningSequence: [false]})
+    const terminal = await openTerminal(mock)
+
+    await terminal.close()
+
+    const script = mock.reapScripts[0]
+    // Highest pid first; the shell is the oldest and lowest, and gets hung up last so it
+    // can wait() on the children it just outlived. Killing it first strands them on pid 1.
+    expect(script).toContain('sort -rn')
+    expect(script.indexOf('kill -HUP "$p"')).toBeLessThan(script.indexOf('kill -HUP "$shell"'))
+    expect(script).toMatch(/kill -HUP "\$p".*sleep 1.*kill -HUP "\$shell"/)
+  })
+
+  test('the session tag is generated internally, never taken from options', async () => {
+    const mock = createContainerMock()
+    // A caller-supplied id would land inside a shell command run in the container.
+    await openTerminal(mock, {id: '"; rm -rf /; #', tag: 'evil'})
+
+    expect(sessionOptions(mock).Env[0]).toMatch(/^ODAC_TTY_SESSION=[a-f0-9]{32}$/)
+  })
+
+  test('fires onExit exactly once with the exit code, even on repeated close', async () => {
+    const mock = createContainerMock({runningSequence: [false]})
+    const onExit = jest.fn()
+    const terminal = await openTerminal(mock, {onExit})
+
+    await terminal.close()
+    await terminal.close()
+
+    expect(onExit).toHaveBeenCalledTimes(1)
+    expect(onExit).toHaveBeenCalledWith({reason: 'closed', exitCode: 0})
+  })
+
+  test('a shell that exits on its own closes the session as "exited"', async () => {
+    const mock = createContainerMock({runningSequence: [false]})
+    const onExit = jest.fn()
+    const terminal = await openTerminal(mock, {onExit})
+
+    mock.sessionStream.end()
+    await new Promise(r => setTimeout(r, 20))
+
+    expect(onExit).toHaveBeenCalledWith({reason: 'exited', exitCode: 0})
+    expect(terminal.closed).toBe(true)
+  })
+
+  test('survives a container that vanished before the reap', async () => {
+    const mock = createContainerMock({runningSequence: [false]})
+    const onExit = jest.fn()
+    const terminal = await openTerminal(mock, {onExit})
+
+    mock.container.exec.mockRejectedValue(new Error('No such container'))
+
+    await expect(terminal.close()).resolves.toBeUndefined()
+    expect(onExit).toHaveBeenCalledTimes(1)
+    expect(terminal.closed).toBe(true)
+  })
+})
+
+describe('Terminal timeouts', () => {
+  afterEach(() => jest.useRealTimers())
+
+  test('closes an idle session and input pushes the deadline back', async () => {
+    jest.useFakeTimers()
+    const mock = createContainerMock({runningSequence: [false]})
+    const onExit = jest.fn()
+    const terminal = await openTerminal(mock, {onExit, idleTimeout: 1000, maxLifetime: 0})
+
+    await jest.advanceTimersByTimeAsync(900)
+    terminal.write('x') // resets the idle timer
+    await jest.advanceTimersByTimeAsync(900)
+    expect(onExit).not.toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(200)
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({reason: 'idle'}))
+  })
+
+  test('output alone does not keep an abandoned session alive', async () => {
+    jest.useFakeTimers()
+    const mock = createContainerMock({runningSequence: [false]})
+    const onExit = jest.fn()
+    await openTerminal(mock, {onExit, idleTimeout: 1000, maxLifetime: 0})
+
+    await jest.advanceTimersByTimeAsync(600)
+    mock.sessionStream.write('chatty process output')
+    await jest.advanceTimersByTimeAsync(600)
+
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({reason: 'idle'}))
+  })
+
+  test('enforces a hard lifetime cap regardless of activity', async () => {
+    jest.useFakeTimers()
+    const mock = createContainerMock({runningSequence: [false]})
+    const onExit = jest.fn()
+    const terminal = await openTerminal(mock, {onExit, idleTimeout: 1000, maxLifetime: 2500})
+
+    // Steady input keeps resetting the idle timer (last reset at 2400 → would fire at 3400),
+    // so the cap at 2500 is the only thing that can end this session.
+    for (let i = 0; i < 3; i++) {
+      await jest.advanceTimersByTimeAsync(800)
+      terminal.write('x')
+    }
+    expect(onExit).not.toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(200)
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({reason: 'lifetime'}))
+  })
+
+  test('a timeout of 0 disables the timer', async () => {
+    jest.useFakeTimers()
+    const mock = createContainerMock({runningSequence: [false]})
+    const onExit = jest.fn()
+    await openTerminal(mock, {onExit, idleTimeout: 0, maxLifetime: 0})
+
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000)
+    expect(onExit).not.toHaveBeenCalled()
+  })
+})

--- a/test/server/Updater.test.js
+++ b/test/server/Updater.test.js
@@ -1,0 +1,434 @@
+/**
+ * Unit tests for server/src/System/Updater.js
+ *
+ * These tests drive the real Updater module against a stateful fake Docker
+ * daemon (a Map of container name -> {policy, running}) instead of mocking
+ * individual method calls, because the bugs this file guards against are
+ * about *sequences* of Docker operations (rename/update/remove ordering)
+ * producing an unsafe intermediate state, not about any single call.
+ *
+ * Real `fs` and `net` are used (not mocked) for the socket-handshake tests:
+ * the regressions covered here are about actual unix-socket behavior and
+ * actual container identity resolution, which a mocked fs/net would hide.
+ */
+
+const path = require('path')
+const fs = require('fs')
+const net = require('net')
+const os = require('os')
+
+function waitUntil(predicate, {timeout = 2000, interval = 10} = {}) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now()
+    const tick = () => {
+      if (predicate()) return resolve()
+      if (Date.now() - start > timeout) return reject(new Error('waitUntil: timed out waiting for condition'))
+      setTimeout(tick, interval)
+    }
+    tick()
+  })
+}
+
+// Force the Linux zero-downtime branch everywhere. The Windows/Mac branch of
+// execute() calls process.exit(0), which would kill the test worker.
+const originalPlatform = process.platform
+beforeAll(() => {
+  Object.defineProperty(process, 'platform', {value: 'linux', configurable: true})
+})
+afterAll(() => {
+  Object.defineProperty(process, 'platform', {value: originalPlatform, configurable: true})
+})
+
+describe('Updater', () => {
+  let world // Map<name, {policy, running, env, binds}>
+  let idIndex // Map<fakeContainerId, name> - used only by the identity-probe test
+  let events // string[] - log of mutating Docker calls, in order
+  let HOME
+  let Updater
+
+  const realExistsSync = fs.existsSync
+  const realReadFileSync = fs.readFileSync
+  let dockerenvExists
+  let procFiles // Map<path, string> - content served for /proc/* reads; absent => ENOENT
+
+  function makeFakeDockerClass() {
+    return class FakeDocker {
+      getContainer(key) {
+        const resolved = world.has(key) ? key : idIndex.get(key)
+        const miss = () => {
+          const e = new Error(`No such container: ${key}`)
+          e.statusCode = 404
+          throw e
+        }
+        return {
+          inspect: async () => {
+            if (!resolved || !world.has(resolved)) miss()
+            const c = world.get(resolved)
+            return {
+              Id: resolved,
+              Name: '/' + resolved,
+              Config: {Env: c.env || []},
+              HostConfig: {Binds: c.binds || [], RestartPolicy: {Name: c.policy}},
+              State: {Running: !!c.running},
+              Mounts: []
+            }
+          },
+          rename: async ({name: to}) => {
+            if (!resolved || !world.has(resolved)) miss()
+            if (world.has(to)) throw new Error(`name ${to} already in use`)
+            world.set(to, world.get(resolved))
+            world.delete(resolved)
+            events.push(`rename:${resolved}->${to}`)
+          },
+          update: async o => {
+            if (!resolved || !world.has(resolved)) miss()
+            world.get(resolved).policy = o.RestartPolicy.Name
+            events.push(`policy:${resolved}=${o.RestartPolicy.Name}`)
+          },
+          remove: async () => {
+            if (!resolved || !world.has(resolved)) miss()
+            world.delete(resolved)
+            events.push(`remove:${resolved}`)
+          },
+          start: async () => {
+            if (resolved && world.has(resolved)) world.get(resolved).running = true
+            events.push(`start:${resolved}`)
+          },
+          stop: async () => {
+            if (resolved && world.has(resolved)) world.get(resolved).running = false
+          },
+          logs: async () => {
+            throw new Error('no logs available in test harness')
+          }
+        }
+      }
+
+      async createContainer(opts) {
+        world.set(opts.name, {policy: opts.HostConfig.RestartPolicy.Name, running: false, env: opts.Env, binds: opts.HostConfig.Binds})
+        events.push(`create:${opts.name}:policy=${opts.HostConfig.RestartPolicy.Name}`)
+        return this.getContainer(opts.name)
+      }
+    }
+  }
+
+  function loadUpdater() {
+    jest.resetModules()
+    jest.doMock('dockerode', () => makeFakeDockerClass())
+    // Real docker/exec is never wanted in a unit test; fail fast and deterministically.
+    jest.doMock('child_process', () => ({exec: jest.fn((cmd, cb) => cb(new Error('exec disabled in tests')))}))
+    Updater = require('../../server/src/System/Updater')
+    return Updater
+  }
+
+  beforeEach(() => {
+    world = new Map()
+    idIndex = new Map()
+    events = []
+    dockerenvExists = true
+    procFiles = new Map()
+
+    HOME = path.join('/tmp', `odac-test-${process.pid}-${Math.random().toString(36).slice(2, 10)}`)
+    fs.mkdirSync(path.join(HOME, '.odac', 'run'), {recursive: true})
+    // os.homedir() reads the process's native env snapshot, which jest's test
+    // environment does not keep in sync with JS-level process.env writes -
+    // spy on the function directly instead of relying on process.env.HOME.
+    jest.spyOn(os, 'homedir').mockReturnValue(HOME)
+
+    jest.spyOn(fs, 'existsSync').mockImplementation(p => {
+      if (p === '/.dockerenv') return dockerenvExists
+      return realExistsSync(p)
+    })
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p, enc) => {
+      if (procFiles.has(p)) return procFiles.get(p)
+      if (typeof p === 'string' && p.startsWith('/proc/')) {
+        const e = new Error(`ENOENT: ${p}`)
+        e.code = 'ENOENT'
+        throw e
+      }
+      return realReadFileSync(p, enc)
+    })
+
+    // #performHandshake's ACK branch awaits these; the default global Odac
+    // mock doesn't define them at all.
+    global.Odac.server('Proxy').waitForReady = jest.fn().mockResolvedValue(true)
+    global.Odac.server('DNS').waitForReady = jest.fn().mockResolvedValue(true)
+
+    if (process.env.UPDATER_TEST_DEBUG) {
+      global.Odac.core('Log').init = jest.fn(name => ({
+        log: (...a) => fs.appendFileSync('/tmp/updater-test-trace.log', `[${name}] ${a.join(' ')}\n`),
+        error: (...a) => fs.appendFileSync('/tmp/updater-test-trace.log', `[${name}:ERR] ${a.join(' ')}\n`),
+        warn: (...a) => fs.appendFileSync('/tmp/updater-test-trace.log', `[${name}:WARN] ${a.join(' ')}\n`)
+      }))
+    }
+
+    loadUpdater()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    fs.rmSync(HOME, {recursive: true, force: true})
+  })
+
+  describe('startup self-heal (init)', () => {
+    test('does nothing on a healthy host', async () => {
+      world.set('odac', {policy: 'unless-stopped', running: true})
+      await Updater.init()
+      expect(events).toEqual([])
+    })
+
+    test("preserves an operator's deliberate 'always' policy", async () => {
+      world.set('odac', {policy: 'always', running: true})
+      await Updater.init()
+      expect(events).toEqual([])
+    })
+
+    test('repairs a container left on RestartPolicy "no"', async () => {
+      world.set('odac', {policy: 'no', running: true})
+      await Updater.init()
+      expect(events).toEqual(['policy:odac=unless-stopped'])
+    })
+
+    test('reclaims identity and repairs policy when stranded as odac-backup', async () => {
+      // This is the exact state a host is left in when a crashed update's
+      // rollback renamed the survivor back... except the rename itself never
+      // happened, or a pre-fix version of the code left it here.
+      world.set('odac-backup', {policy: 'no', running: true})
+      await Updater.init()
+      expect(events).toEqual(['rename:odac-backup->odac', 'policy:odac=unless-stopped'])
+    })
+
+    test('reclaims identity and repairs policy when stranded as odac-update', async () => {
+      world.set('odac-update', {policy: 'no', running: true})
+      await Updater.init()
+      expect(events).toEqual(['rename:odac-update->odac', 'policy:odac=unless-stopped'])
+    })
+
+    test('leaves a stale exited backup alone next to a healthy odac', async () => {
+      world.set('odac', {policy: 'unless-stopped', running: true})
+      world.set('odac-backup', {policy: 'no', running: false})
+      await Updater.init()
+      expect(events).toEqual([])
+    })
+
+    test('does nothing outside a container (dev host)', async () => {
+      dockerenvExists = false
+      world.set('odac-backup', {policy: 'no', running: true})
+      await Updater.init()
+      expect(events).toEqual([])
+    })
+
+    test('does nothing when identity cannot be resolved at all', async () => {
+      // No 'odac', no 'odac-backup', no 'odac-update' anywhere.
+      await Updater.init()
+      expect(events).toEqual([])
+    })
+
+    test('resolves identity via /proc/self/cgroup when name lookup fails', async () => {
+      const fakeId = 'a'.repeat(64)
+      procFiles.set('/proc/self/cgroup', `0::/system.slice/docker-${fakeId}.scope\n`)
+      world.set('odac-backup', {policy: 'no', running: true})
+      idIndex.set(fakeId, 'odac-backup')
+
+      await Updater.init()
+      expect(events).toEqual(['rename:odac-backup->odac', 'policy:odac=unless-stopped'])
+    })
+  })
+
+  describe('zero-downtime takeOver invariant', () => {
+    test('never leaves more than one container able to auto-start, and reboot resolves to the new odac', async () => {
+      world.set('odac', {policy: 'unless-stopped', running: true}) // old, live
+      world.set('odac-update', {policy: 'no', running: true}) // new, that's the real Updater under test
+
+      const socketPath = path.join(HOME, '.odac', 'run', 'update.sock')
+      const PERSISTENT = p => p === 'always' || p === 'unless-stopped'
+      const snapshots = []
+      const snap = label => {
+        const autostart = [...world.entries()].filter(([, c]) => PERSISTENT(c.policy) && c.running).map(([n]) => n)
+        snapshots.push({label, autostart: autostart.join(',')})
+      }
+      snap('before')
+
+      // Wrap the fake docker to snapshot after every mutation, mirroring what
+      // an OS reboot would resurrect at that instant.
+      const wrappedPush = events.push.bind(events)
+      events.push = (...a) => {
+        const r = wrappedPush(...a)
+        snap(a[0])
+        return r
+      }
+
+      // Hand-scripted OLD container side: implements the documented protocol
+      // (see comments in Updater.js #createUpdateListener) without calling any
+      // real Updater code, so the real #takeOver() below is the only thing
+      // actually under test.
+      await new Promise((resolve, reject) => {
+        const dbg = process.env.UPDATER_TEST_DEBUG ? line => fs.appendFileSync('/tmp/updater-test-trace.log', line + '\n') : () => {}
+        dbg(`--- test start, socketPath=${socketPath} ---`)
+        const server = net.createServer(sock => {
+          dbg('[test-server] connection accepted')
+          sock.on('data', d => {
+            const msg = d.toString().trim()
+            dbg(`[test-server] got: ${JSON.stringify(msg)}`)
+            if (msg === 'HANDSHAKE_READY') sock.write('HANDSHAKE_ACK')
+            else if (msg === 'WEB_READY') {
+              server.close()
+              resolve()
+            }
+          })
+          sock.on('error', e => dbg(`[test-server] sock error: ${e.message}`))
+          sock.on('close', () => dbg('[test-server] sock closed'))
+        })
+        server.on('error', reject)
+        server.listen(socketPath, () => {
+          Updater.init().catch(reject) // the NEW container joining: real performHandshake + real takeOver()
+        })
+      })
+
+      expect(snapshots.every(s => s.autostart.split(',').filter(Boolean).length <= 1)).toBe(true)
+      expect(snapshots[snapshots.length - 1].autostart).toBe('odac')
+      expect(world.get('odac')?.policy).toBe('unless-stopped')
+      expect(world.get('odac-backup')?.policy).toBe('no')
+      expect(world.has('odac-update')).toBe(false)
+    })
+  })
+
+  describe('rollback safety', () => {
+    test('crash right after takeOver does not self-handshake and leaves the new odac running', async () => {
+      world.set('odac', {
+        policy: 'unless-stopped',
+        running: true,
+        env: ['ODAC_CHANNEL=stable'],
+        binds: [`${HOME}/.odac:/app/.odac`]
+      })
+
+      // Rollback restarts services via System.init(), which for real would
+      // re-enter Updater.init(). Point that straight at the real Updater
+      // singleton under test so the self-handshake regression has a real
+      // listener to reconnect to if it reappears.
+      global.Odac.server('System').init = jest.fn(() => Updater.init())
+
+      const execPromise = Updater.execute()
+
+      await waitUntil(() => events.some(e => e.startsWith('create:odac-update')))
+      const socketPath = path.join(HOME, '.odac', 'run', 'update.sock')
+      await waitUntil(() => fs.existsSync(socketPath))
+
+      const sock = net.createConnection(socketPath)
+      await new Promise((resolve, reject) => {
+        sock.on('connect', () => sock.write('HANDSHAKE_READY'))
+        sock.on('error', reject)
+        sock.on('data', async d => {
+          if (d.toString().trim() !== 'HANDSHAKE_ACK') return
+          // Perform the real #takeOver() semantics as the new container would,
+          // then crash before TAKEOVER_COMPLETE.
+          const docker = new (makeFakeDockerClass())()
+          await docker.getContainer('odac').rename({name: 'odac-backup'})
+          await docker.getContainer('odac-backup').update({RestartPolicy: {Name: 'no'}})
+          await docker.getContainer('odac-update').rename({name: 'odac'})
+          await docker.getContainer('odac').update({RestartPolicy: {Name: 'unless-stopped'}})
+          sock.destroy()
+          resolve()
+        })
+      })
+
+      await expect(execPromise).rejects.toThrow()
+
+      // The critical assertion: rollback must not have handshaked with itself
+      // and undone the takeover. If it had, this would read 'odac-backup' only.
+      expect(world.has('odac')).toBe(true)
+      expect(world.get('odac').policy).toBe('unless-stopped')
+      expect(world.get('odac').running).toBe(true)
+      // The crashed new instance must be gone, but the live container that was
+      // running inside the process handling rollback must never be force-removed.
+      expect(events).not.toContain('remove:odac')
+    })
+
+    test('crash before takeOver never force-removes the still-live odac container', async () => {
+      world.set('odac', {
+        policy: 'unless-stopped',
+        running: true,
+        env: ['ODAC_CHANNEL=stable'],
+        binds: [`${HOME}/.odac:/app/.odac`]
+      })
+      global.Odac.server('System').init = jest.fn(() => Updater.init())
+
+      const execPromise = Updater.execute()
+
+      await waitUntil(() => events.some(e => e.startsWith('create:odac-update')))
+      const socketPath = path.join(HOME, '.odac', 'run', 'update.sock')
+      await waitUntil(() => fs.existsSync(socketPath))
+
+      const sock = net.createConnection(socketPath)
+      await new Promise((resolve, reject) => {
+        sock.on('connect', () => sock.write('HANDSHAKE_READY'))
+        sock.on('error', reject)
+        sock.on('data', d => {
+          if (d.toString().trim() !== 'HANDSHAKE_ACK') return
+          // Crash immediately, before doing anything takeOver() would do.
+          sock.destroy()
+          resolve()
+        })
+      })
+
+      await expect(execPromise).rejects.toThrow()
+
+      // Pre-fix behavior: rollback force-removed whatever was named 'odac',
+      // which at this point is the live container itself.
+      expect(events).not.toContain('remove:odac')
+      expect(world.has('odac')).toBe(true)
+      expect(world.get('odac').running).toBe(true)
+      expect(world.get('odac').policy).toBe('unless-stopped')
+    })
+  })
+
+  describe('update env accumulation', () => {
+    test('strips all update-cycle env vars from the inherited env instead of two of five', async () => {
+      world.set('odac', {
+        policy: 'unless-stopped',
+        running: true,
+        env: [
+          'PATH=/usr/bin',
+          'ODAC_CHANNEL=stable',
+          // Simulates a host that went through the pre-fix update path at
+          // least once: these should have been stripped and weren't.
+          'ODAC_UPDATE_MODE=true',
+          'ODAC_INSTANCE_ID=stale-instance',
+          'ODAC_PREVIOUS_INSTANCE_ID=stale-previous',
+          'ODAC_UPDATE_SOCKET_PATH=/stale/path.sock',
+          'ODAC_LOG_NAME=.odac-update'
+        ],
+        binds: [`${HOME}/.odac:/app/.odac`]
+      })
+      global.Odac.server('System').init = jest.fn(() => Updater.init())
+
+      const execPromise = Updater.execute()
+      await waitUntil(() => events.some(e => e.startsWith('create:odac-update')))
+
+      const newEnv = world.get('odac-update').env
+      const countOf = key => newEnv.filter(e => e.startsWith(`${key}=`)).length
+
+      for (const key of ['ODAC_UPDATE_MODE', 'ODAC_INSTANCE_ID', 'ODAC_PREVIOUS_INSTANCE_ID', 'ODAC_UPDATE_SOCKET_PATH', 'ODAC_LOG_NAME']) {
+        expect(countOf(key)).toBe(1)
+      }
+      expect(newEnv.find(e => e.startsWith('ODAC_INSTANCE_ID='))).not.toBe('ODAC_INSTANCE_ID=stale-instance')
+      expect(newEnv).toContain('PATH=/usr/bin')
+      expect(newEnv).toContain('ODAC_CHANNEL=stable')
+
+      // Unblock execute() so the test doesn't leave dangling timers/handles.
+      const socketPath = path.join(HOME, '.odac', 'run', 'update.sock')
+      await waitUntil(() => fs.existsSync(socketPath))
+      const sock = net.createConnection(socketPath)
+      await new Promise(resolve => {
+        sock.on('connect', () => sock.write('HANDSHAKE_READY'))
+        sock.on('data', d => {
+          if (d.toString().trim() === 'HANDSHAKE_ACK') {
+            sock.destroy()
+            resolve()
+          }
+        })
+        sock.on('error', resolve)
+      })
+      await expect(execPromise).rejects.toThrow()
+    })
+  })
+})

--- a/test/server/__mocks__/globalOdac.js
+++ b/test/server/__mocks__/globalOdac.js
@@ -76,6 +76,9 @@ class MockOdac {
 
     // Default mocks for server modules
     const serverMocks = {
+      // Pure, stateless value object — the real implementation *is* the contract
+      // exercised wherever ports are read or written.
+      Ports: require('../../../server/src/Ports'),
       Api: {
         init: jest.fn(),
         start: jest.fn(),

--- a/test/server/deviceAdd.test.js
+++ b/test/server/deviceAdd.test.js
@@ -22,6 +22,9 @@ global.Odac = {
     return {}
   }),
   server: jest.fn(module => {
+    if (module === 'Ports') {
+      return require('../../server/src/Ports')
+    }
     if (module === 'Api') {
       return {
         result: jest.fn((result, message, data) => ({result, success: result, message, data}))

--- a/test/server/deviceDelete.test.js
+++ b/test/server/deviceDelete.test.js
@@ -22,6 +22,9 @@ global.Odac = {
     return {}
   }),
   server: jest.fn(module => {
+    if (module === 'Ports') {
+      return require('../../server/src/Ports')
+    }
     if (module === 'Api') {
       return {
         result: jest.fn((result, message, data) => ({result, success: result, message, data}))


### PR DESCRIPTION
This PR includes the following changes:

* fix: gate port auto-discovery on an HTTP probe, not a guess
* fix: update sensitive key masking in App and tests
* feat: Implement terminal management in Hub
* refactor: enhance port management and public flag handling
* feat: enhance port management with explicit proxy handling and validation
* test(updater): cover the restart-policy, identity, rollback and env-accumulation fixes
* fix(updater): keep the odac container recoverable across updates and crashes